### PR TITLE
Feat/2 entity add : 기사 관련 엔티티 초기 생성 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### applications ###
+/src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,14 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-orgjson', version: '0.11.2'
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.2'
+
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // security
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/onlinenews/article/entity/Article.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Article.java
@@ -1,0 +1,70 @@
+package com.example.onlinenews.article.entity;
+
+import com.example.onlinenews.article_img.entity.ArticleImg;
+import com.example.onlinenews.like.entity.Like;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //기자 id 넣을 예정 - User
+    //private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String subtitle;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime created_at;
+
+    @Column
+    @LastModifiedDate
+    private LocalDateTime modified_at;
+
+    @Column
+    private LocalDateTime hold_at;
+
+    @Column
+    private LocalDateTime approved_at;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private State state;
+
+    @Column(nullable = false)
+    private Boolean is_public;
+
+    @Column(nullable = false)
+    private int views = 0;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ArticleImg> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Like> likes = new ArrayList<>();
+}

--- a/src/main/java/com/example/onlinenews/article/entity/Category.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Category.java
@@ -1,0 +1,24 @@
+package com.example.onlinenews.article.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Category {
+    SOCIAL("사회"),
+    ECONOMY("경제"),
+    LIFE_CULTURE("생활/문화"),
+    ENTERTAINMENT("연예"),
+    SCIENCE_TECH("과학/기술");
+
+    private final String description;
+
+    // 생성자
+    Category(String description) {
+        this.description = description;
+    }
+
+    // 한글 설명을 리턴하는 메소드
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/onlinenews/article/entity/State.java
+++ b/src/main/java/com/example/onlinenews/article/entity/State.java
@@ -1,10 +1,14 @@
 package com.example.onlinenews.article.entity;
 
-public enum State {
+import lombok.Getter;
+
+@Getter
+public enum State{
     REQUESTED("승인 요청된 상태"),
     HOLDING("승인 보류된 상태"),
     APPROVED("기사 승인된 상태");
 
+    // 한글 설명을 리턴하는 메소드
     private final String description;
 
     // 생성자
@@ -12,8 +16,4 @@ public enum State {
         this.description = description;
     }
 
-    // 한글 설명을 리턴하는 메소드
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/com/example/onlinenews/article/entity/State.java
+++ b/src/main/java/com/example/onlinenews/article/entity/State.java
@@ -1,0 +1,19 @@
+package com.example.onlinenews.article.entity;
+
+public enum State {
+    REQUESTED("승인 요청된 상태"),
+    HOLDING("승인 보류된 상태"),
+    APPROVED("기사 승인된 상태");
+
+    private final String description;
+
+    // 생성자
+    State(String description) {
+        this.description = description;
+    }
+
+    // 한글 설명을 리턴하는 메소드
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/onlinenews/article_img/entity/ArticleImg.java
+++ b/src/main/java/com/example/onlinenews/article_img/entity/ArticleImg.java
@@ -1,0 +1,23 @@
+package com.example.onlinenews.article_img.entity;
+
+import com.example.onlinenews.article.entity.Article;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArticleImg {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Article article;
+
+    @Column(nullable = false)
+    private String imgUrl;
+}

--- a/src/main/java/com/example/onlinenews/comment/entity/Comment.java
+++ b/src/main/java/com/example/onlinenews/comment/entity/Comment.java
@@ -1,0 +1,48 @@
+package com.example.onlinenews.comment.entity;
+
+import com.example.onlinenews.article.entity.Article;
+import jakarta.persistence.*;
+import lombok.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //private User user;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Article article;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime created_at;
+
+    @Column(nullable = false)
+    private int like_count = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    @JsonIgnore
+    private Comment parent;  // 부모 댓글 (null이면 최상위 댓글)
+
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> replies = new ArrayList<>();  // 대댓글 리스트
+
+}

--- a/src/main/java/com/example/onlinenews/config/SecurityConfig.java
+++ b/src/main/java/com/example/onlinenews/config/SecurityConfig.java
@@ -1,0 +1,83 @@
+package com.example.onlinenews.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.io.IOException;
+
+@Configuration
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests((registry) ->
+                                registry.requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 관련 경로 허용
+                                //이 사이에 권한 인증 요구 추가 .requestMatchers(<특정 API>).authentication()
+                                 .anyRequest().permitAll()
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .accessDeniedHandler(new AccessDeniedHandler() {
+                            @Override
+                            public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException, IOException {
+                                response.setStatus(403);
+                                response.setCharacterEncoding("utf-8");
+                                response.setContentType("text/html; charset=UTF-8");
+                                response.getWriter().write("권한이 없는 사용자입니다.");
+                            }
+                        })
+                        .authenticationEntryPoint(new AuthenticationEntryPoint() {
+                            @Override
+                            public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+                                response.setStatus(401);
+                                response.setCharacterEncoding("utf-8");
+                                response.setContentType("text/html; charset=UTF-8");
+                                response.getWriter().write("인증되지 않은 사용자입니다.");
+                            }
+                        })
+                )
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:8080");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/example/onlinenews/config/SwaggerConfig.java
+++ b/src/main/java/com/example/onlinenews/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.example.onlinenews.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI OpenApi() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo(){
+        return new Info()
+                .title("OnlineNews Swagger")
+                .description("OnlineNews API 명세")
+                .version("1.0");
+    }
+}

--- a/src/main/java/com/example/onlinenews/like/entity/Like.java
+++ b/src/main/java/com/example/onlinenews/like/entity/Like.java
@@ -1,0 +1,30 @@
+package com.example.onlinenews.like.entity;
+
+import com.example.onlinenews.article.entity.Article;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // private User user
+
+    @ManyToOne
+    private Article article;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime created_at;
+
+}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🔔 변경 사항
>  User 엔티티가 없어서 나중에 추가되면 속성 수정하겠습니다. 


### 1. Entity 파일 추가 : User 속성 추가 전 
-  Article (기사)
-  ArticleImg (기사이미지)
-  Comment(댓글/대댓글)
-  Like (좋아요) 

### 2. Enum 파일 추가 
- Category : Article의 카테고리 관련 enum 
- State : Article의 상태(승인요청/보류/승인완료) enum 

## ✅ 테스트 결과