### PR TITLE
Feat/#2 entity add : 기사 관련 엔티티 초기 생성 

### DIFF
--- a/src/main/java/com/example/onlinenews/article/entity/Article.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Article.java
@@ -1,0 +1,70 @@
+package com.example.onlinenews.article.entity;
+
+import com.example.onlinenews.article_img.entity.ArticleImg;
+import com.example.onlinenews.like.entity.Like;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //기자 id 넣을 예정 - User
+    //private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String subtitle;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime created_at;
+
+    @Column
+    @LastModifiedDate
+    private LocalDateTime modified_at;
+
+    @Column
+    private LocalDateTime hold_at;
+
+    @Column
+    private LocalDateTime approved_at;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private State state;
+
+    @Column(nullable = false)
+    private Boolean is_public;
+
+    @Column(nullable = false)
+    private int views = 0;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ArticleImg> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Like> likes = new ArrayList<>();
+}

--- a/src/main/java/com/example/onlinenews/article/entity/Category.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Category.java
@@ -1,0 +1,24 @@
+package com.example.onlinenews.article.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Category {
+    SOCIAL("사회"),
+    ECONOMY("경제"),
+    LIFE_CULTURE("생활/문화"),
+    ENTERTAINMENT("연예"),
+    SCIENCE_TECH("과학/기술");
+
+    private final String description;
+
+    // 생성자
+    Category(String description) {
+        this.description = description;
+    }
+
+    // 한글 설명을 리턴하는 메소드
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/onlinenews/article/entity/State.java
+++ b/src/main/java/com/example/onlinenews/article/entity/State.java
@@ -1,10 +1,14 @@
 package com.example.onlinenews.article.entity;
 
-public enum State {
+import lombok.Getter;
+
+@Getter
+public enum State{
     REQUESTED("승인 요청된 상태"),
     HOLDING("승인 보류된 상태"),
     APPROVED("기사 승인된 상태");
 
+    // 한글 설명을 리턴하는 메소드
     private final String description;
 
     // 생성자
@@ -12,8 +16,4 @@ public enum State {
         this.description = description;
     }
 
-    // 한글 설명을 리턴하는 메소드
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/com/example/onlinenews/article/entity/State.java
+++ b/src/main/java/com/example/onlinenews/article/entity/State.java
@@ -1,0 +1,19 @@
+package com.example.onlinenews.article.entity;
+
+public enum State {
+    REQUESTED("승인 요청된 상태"),
+    HOLDING("승인 보류된 상태"),
+    APPROVED("기사 승인된 상태");
+
+    private final String description;
+
+    // 생성자
+    State(String description) {
+        this.description = description;
+    }
+
+    // 한글 설명을 리턴하는 메소드
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/onlinenews/article_img/entity/ArticleImg.java
+++ b/src/main/java/com/example/onlinenews/article_img/entity/ArticleImg.java
@@ -1,0 +1,23 @@
+package com.example.onlinenews.article_img.entity;
+
+import com.example.onlinenews.article.entity.Article;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArticleImg {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Article article;
+
+    @Column(nullable = false)
+    private String imgUrl;
+}

--- a/src/main/java/com/example/onlinenews/comment/entity/Comment.java
+++ b/src/main/java/com/example/onlinenews/comment/entity/Comment.java
@@ -1,0 +1,48 @@
+package com.example.onlinenews.comment.entity;
+
+import com.example.onlinenews.article.entity.Article;
+import jakarta.persistence.*;
+import lombok.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //private User user;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Article article;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime created_at;
+
+    @Column(nullable = false)
+    private int like_count = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    @JsonIgnore
+    private Comment parent;  // 부모 댓글 (null이면 최상위 댓글)
+
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> replies = new ArrayList<>();  // 대댓글 리스트
+
+}

--- a/src/main/java/com/example/onlinenews/like/entity/Like.java
+++ b/src/main/java/com/example/onlinenews/like/entity/Like.java
@@ -1,0 +1,30 @@
+package com.example.onlinenews.like.entity;
+
+import com.example.onlinenews.article.entity.Article;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // private User user
+
+    @ManyToOne
+    private Article article;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime created_at;
+
+}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
>  User 엔티티가 없어서 나중에 추가되면 속성 수정하겠습니다. 

### 1. Entity 파일 추가 : User 속성 추가 전 
-  Article (기사)
-  ArticleImg (기사이미지)
-  Comment(댓글/대댓글)
-  Like (좋아요) 

### 2. Enum 파일 추가 
- Category : Article의 카테고리 관련 enum 
- State : Article의 상태(승인요청/보류/승인완료) enum 

## ✅ 테스트 결과

## 🔖 관련 이슈
### #2 [feat] 기사 관련 엔티티 생성 