### PR TITLE
feat: error 통합 처리

### DIFF
--- a/src/main/java/com/example/onlinenews/error/BusinessException.java
+++ b/src/main/java/com/example/onlinenews/error/BusinessException.java
@@ -1,0 +1,16 @@
+package com.example.onlinenews.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    // runtimeException 발생시 날려줄 메시지들을 enum에 작성해놓고,
+    // CustomException(현재 클래스) 에서 enum 객체를 생성
+    private final ExceptionCode exceptionCode;
+
+    public BusinessException(ExceptionCode exceptionCode){
+
+        this.exceptionCode = exceptionCode;
+    }
+
+}

--- a/src/main/java/com/example/onlinenews/error/ErrorResponse.java
+++ b/src/main/java/com/example/onlinenews/error/ErrorResponse.java
@@ -1,0 +1,94 @@
+package com.example.onlinenews.error;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+@Data
+public class ErrorResponse {
+    private int status;
+    private String code;
+    private String message;
+    private List<FieldError> errors;    // 상세 에러 메시지
+    private String reason;              // 에러 이유
+
+    @Builder
+    public ErrorResponse(final ExceptionCode code) {
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.errors = new ArrayList<>();
+    }
+
+    @Builder
+    protected ErrorResponse(final ExceptionCode code, final String reason) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.reason = reason;
+    }
+
+    @Builder
+    protected ErrorResponse(final ExceptionCode code, final List<FieldError> errors) {
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.message = message;  // 주어진 메시지를 사용합니다.
+        this.errors = errors;
+    }
+
+
+    public static ErrorResponse of(final ExceptionCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    @Builder
+    public static ErrorResponse of(final ExceptionCode code) {
+        return new ErrorResponse(code);
+    }
+
+    @Builder
+    public static ErrorResponse of(final ExceptionCode code, final String reason){
+        return new ErrorResponse(code, reason);
+    }
+
+
+    /**
+     * 에러를 e.getBindingResult() 형태로 전달 받는 경우 해당 내용을 상세 내용으로 변경하는 기능을 수행한다.
+     */
+    @Getter
+    public static class FieldError {
+        private final String field;
+        private final String value;
+        private final String reason;
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+
+        @Builder
+        FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+    }
+}

--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -1,0 +1,40 @@
+package com.example.onlinenews.error;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionCode {
+
+
+    ARTICLE_NOT_FOUND(404, "POST_001", "해당되는 id 의 기사를 찾을 수 없습니다."),
+    REPLY_NOT_FOUND(404, "REPLY_001", "해당되는 id의 댓글을 찾을 수 없습니다."),
+    ALREADY_LIKED(400, "LIKE_001", "이미 '좋아요'를 누른 상태입니다."),
+
+
+
+    USER_NOT_FOUND(404, "USER_004", "해당 유저를 찾을 수 없습니다."),
+    TOKEN_NOT_VALID(401, "TOKEN_001", "토큰이 만료되었습니다. 다시 로그인 해주세요."),
+    USER_CAN_NOT_BE_NULL(400, "USER_005", "사용자는 null이 될 수 없습니다."),
+    USER_ID_NOT_FOUND(404, "USER_006", "해당되는 id의 사용자를 찾을 수 없습니다."),
+
+
+    NULL_POINT_ERROR(404, "G010", "NullPointerException 발생"),
+
+    // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
+    NOT_VALID_ERROR(404, "G011", "Validation Exception 발생");
+
+
+    // 1. status = 날려줄 상태코드
+    // 2. code = 해당 오류가 어느부분과 관련있는지 카테고리화 해주는 코드. 예외 원인 식별하기 편하기에 추가
+    // 3. message = 발생한 예외에 대한 설명.
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    ExceptionCode(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/onlinenews/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/onlinenews/error/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.example.onlinenews.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final HttpStatus HTTP_STATUS_OK = HttpStatus.OK;
+
+    //비즈니스 로직의 예외처리(Unchecked Exception 발생시 처리)
+    @ExceptionHandler(BusinessException.class) // 만들어준 커스텀익셉션 발생시 처리해주는 곳
+    public ResponseEntity<ErrorResponse> handleCustomException(BusinessException ex) {
+        log.error("Business Exception Error", ex);
+
+        final ErrorResponse errorResponse = ErrorResponse.of(ex.getExceptionCode(), ex.getMessage());
+
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(errorResponse.getStatus()));
+
+    }
+
+    //여기부턴 클라이언트 측의 잘못된 요청에 의한 에러를 처리해줌.
+    @ExceptionHandler(NullPointerException.class) // nullPointerExceptiono발생시
+    protected ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
+        log.error("handleNullPointerException", e);
+        final ErrorResponse response = ErrorResponse.of(ExceptionCode.NULL_POINT_ERROR, e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+    }
+
+
+    // @valid 유효성 검증에 실패했을 경우 발생하는 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        log.error("handleMethodArgumentNotValidException", ex);
+        BindingResult bindingResult = ex.getBindingResult();
+        StringBuilder stringBuilder = new StringBuilder();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            stringBuilder.append(fieldError.getField()).append(":");
+            stringBuilder.append(fieldError.getDefaultMessage());
+            stringBuilder.append(", ");
+        }
+        final ErrorResponse response = ErrorResponse.of(ExceptionCode.NOT_VALID_ERROR, String.valueOf(stringBuilder));
+        return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+    }
+
+
+}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
1.  `GlobalExceptionHandler` 를 사용하여, 모든 예외 처리를 전역에서 담당
2.  `ErrorCode`  enum 파일에 필요한 에러 추가하며 됩니다. 
```java
 ARTICLE_NOT_FOUND(404, "POST_001", "해당되는 id 의 기사를 찾을 수 없습니다."),
 REPLY_NOT_FOUND(404, "REPLY_001", "해당되는 id의 댓글을 찾을 수 없습니다."),
 ALREADY_LIKED(400, "LIKE_001", "이미 '좋아요'를 누른 상태입니다."),
....
``` 

## ✅ 테스트 
이런 식으로 서비스에서 예외처리를 하고, 컨트롤러에서는 따로 ResponseEntity<?> 를 사용할 필요 없습니다.
### 
```java
public RequestDto getRequest(Long id) {
    return requestRepository.findById(id)
        .map(RequestDto::fromEntity)
        .orElseThrow(() -> new BusinessException(ExceptionCode.NO_DATA_FOUND));
}

``` 

## 🔖 관련 이슈
### #19[feat] error
