### PR TITLE
Feat/#20 security jwt : JWT 지원 사용자 인증 메커니즘 구축 + 로그인 구현 

### DIFF
--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -16,6 +16,7 @@ public enum ExceptionCode {
     USER_CAN_NOT_BE_NULL(400, "USER_005", "사용자는 null이 될 수 없습니다."),
     USER_ID_NOT_FOUND(404, "USER_006", "해당되는 id의 사용자를 찾을 수 없습니다."),
     USER_NOT_ALLOWED(404, "USER_007", "편집장 이상만 가능한 작업입니다."),
+    USER_PASSWORD_INCORRECT(401, "USER_008", "비밀번호가 틀렸습니다."),
 
     EMAIL_CONFLICT(409, "EMAIL_009","이미 존재하는 email입니다. "),
 

--- a/src/main/java/com/example/onlinenews/jwt/dto/JwtToken.java
+++ b/src/main/java/com/example/onlinenews/jwt/dto/JwtToken.java
@@ -1,0 +1,14 @@
+package com.example.onlinenews.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/onlinenews/jwt/entity/CustomUserDetails.java
+++ b/src/main/java/com/example/onlinenews/jwt/entity/CustomUserDetails.java
@@ -1,0 +1,32 @@
+package com.example.onlinenews.jwt.entity;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.example.onlinenews.user.entity.User;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "ROLE_" + user.getGrade());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPw();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+}

--- a/src/main/java/com/example/onlinenews/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/onlinenews/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.example.onlinenews.jwt.filter;
+
+import com.example.onlinenews.error.BusinessException;
+import com.example.onlinenews.error.ExceptionCode;
+import com.example.onlinenews.jwt.provider.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Jwt가 유효성을 검증하는 Filter
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtProvider.resolveToken(request);
+        System.out.println("Resolved Token: " + token);  // 토큰이 올바르게 파싱되는지 확인
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Authentication auth = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } else if(token != null && !jwtProvider.validateToken(token)){
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return; // 인증 실패 시 필터 체인을 더 진행하지 않음
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/onlinenews/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/onlinenews/jwt/filter/JwtAuthenticationFilter.java
@@ -1,17 +1,14 @@
 package com.example.onlinenews.jwt.filter;
 
-import com.example.onlinenews.error.BusinessException;
-import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.jwt.provider.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 /**
  * Jwt가 유효성을 검증하는 Filter
@@ -26,14 +23,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request);
         System.out.println("Resolved Token: " + token);  // 토큰이 올바르게 파싱되는지 확인
 
         if (token != null && jwtProvider.validateToken(token)) {
             Authentication auth = jwtProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(auth);
-        } else if(token != null && !jwtProvider.validateToken(token)){
+        } else if (token != null && !jwtProvider.validateToken(token)) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return; // 인증 실패 시 필터 체인을 더 진행하지 않음
         }

--- a/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
@@ -129,10 +129,9 @@ public class JwtTokenProvider {
      */
     public boolean validateToken(String token) {
         try {
-            if (!token.startsWith(BEARER_PREFIX)) {
-                return false;
+            if (token.startsWith(BEARER_PREFIX)) {
+                token = token.substring(BEARER_PREFIX.length()).trim();
             }
-            token = token.substring(BEARER_PREFIX.length()).trim();
 
             Jws<Claims> claims = Jwts.parserBuilder()
                     .setSigningKey(key)
@@ -140,6 +139,7 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token);
 
             return !claims.getBody().getExpiration().before(new Date());
+
         } catch (Exception e) {
             log.error("Invalid JWT token: {}", token, e);
             return false;

--- a/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
@@ -1,0 +1,184 @@
+package com.example.onlinenews.jwt.provider;
+
+import com.example.onlinenews.jwt.dto.JwtToken;
+import com.example.onlinenews.jwt.service.JpaUserDetailService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.accessExpiration}")
+    private long accessExpiration;
+
+    @Value("${jwt.refreshExpiration}")
+    private long refreshExpiration;
+
+    private Key key;
+
+    private final JpaUserDetailService userDetailService;
+
+    public JwtTokenProvider(JpaUserDetailService userDetailService) {
+        this.userDetailService = userDetailService;
+    }
+
+    @PostConstruct
+    protected void init() {
+        key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(String account) {
+        Claims claims = Jwts.claims().setSubject(account);
+
+        UserDetails userDetails = userDetailService.loadUserByUsername(account);
+        claims.put("role", userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList());
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessExpiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String account) {
+        Claims claims = Jwts.claims().setSubject(account);
+
+        UserDetails userDetails = userDetailService.loadUserByUsername(account);
+        claims.put("role", userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList());
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshExpiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+    /**
+     * JWT 토큰에서 권한 인증하는 메소드
+     *
+     * @param token
+     * @return 인증 정보
+     */
+
+    public Authentication getAuthentication(String token) {
+        String account = this.getAccount(token);
+        UserDetails userDetails = userDetailService.loadUserByUsername(account);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    /**
+     * JWT 토큰에서 email 가져오는 메소드
+     *
+     * @param token
+     * @return email
+     */
+    public String getAccount(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    /**
+     * Http header에서 JWT 토큰을 가져오는 메소드
+     *
+     * @param request
+     * @return JWT 토큰
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        if (token != null && token.startsWith(BEARER_PREFIX)) {
+            return token.substring(BEARER_PREFIX.length()).trim(); // "Bearer " 부분 제거
+        }
+        return null;
+    }
+
+    /**
+     * JWT 유효성 검사 메소드
+     *
+     * @param token
+     * @return 유효성 유무
+     */
+    public boolean validateToken(String token) {
+        try {
+            if (!token.startsWith(BEARER_PREFIX)) {
+                return false;
+            }
+            token = token.substring(BEARER_PREFIX.length()).trim();
+
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.error("Invalid JWT token: {}", token, e);
+            return false;
+        }
+    }
+
+    /**
+     * JWT 토큰 남은 만료 시간
+     *
+     * @param accessToken
+     * @return 남은 시간
+     */
+    public long getExpiration(String accessToken) {
+        Date expriration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();
+
+        long now = new Date().getTime();
+        return expriration.getTime() - now;
+    }
+
+    /**
+     * RefreshToken으로 accessToken 재발급 하는 메소드
+     *
+     * @param refreshToken
+     * @return
+     */
+    public JwtToken reissueToken(String refreshToken) {
+        String email = getAccount(refreshToken);
+
+        JwtToken jwtDto = JwtToken.builder()
+                .accessToken(generateAccessToken(email))
+                .refreshToken(generateRefreshToken(email))
+                .grantType("Bearer")
+                .build();
+
+        return jwtDto;
+    }
+}

--- a/src/main/java/com/example/onlinenews/jwt/service/JpaUserDetailService.java
+++ b/src/main/java/com/example/onlinenews/jwt/service/JpaUserDetailService.java
@@ -1,0 +1,24 @@
+package com.example.onlinenews.jwt.service;
+
+import com.example.onlinenews.error.BusinessException;
+import com.example.onlinenews.error.ExceptionCode;
+import com.example.onlinenews.jwt.entity.CustomUserDetails;
+import com.example.onlinenews.user.entity.User;
+import com.example.onlinenews.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JpaUserDetailService implements UserDetailsService {
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email).orElseThrow(()
+                -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/example/onlinenews/request/service/RequestService.java
+++ b/src/main/java/com/example/onlinenews/request/service/RequestService.java
@@ -9,6 +9,7 @@ import com.example.onlinenews.request.entity.Request;
 import com.example.onlinenews.request.entity.RequestStatus;
 import com.example.onlinenews.request.repository.RequestRepository;
 import com.example.onlinenews.user.entity.User;
+import com.example.onlinenews.user.entity.UserGrade;
 import com.example.onlinenews.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,7 +58,7 @@ public class RequestService {
     @Transactional
     public RequestStatus requestAccept (Long userId, Long reqId){
         User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if(user.getGrade()<9){
+        if(user.getGrade().getValue() < UserGrade.EDITOR.getValue()){
             throw new BusinessException(ExceptionCode.USER_NOT_ALLOWED);
         }
         Request request = requestRepository.findById(reqId).orElseThrow(() -> new BusinessException(ExceptionCode.REQUEST_NOT_FOUND));
@@ -77,7 +78,7 @@ public class RequestService {
     @Transactional
     public RequestStatus requestHold(Long userId, Long reqId, RequestCommentDto requestCommentDto){
         User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if(user.getGrade()<9){
+        if(user.getGrade().getValue() < UserGrade.EDITOR.getValue()){
             throw new BusinessException(ExceptionCode.USER_NOT_ALLOWED);
         }
 
@@ -99,7 +100,7 @@ public class RequestService {
     @Transactional
     public RequestStatus requestReject(Long userId, Long reqId, RequestCommentDto requestCommentDto){
         User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        if(user.getGrade()<9){
+        if(user.getGrade().getValue() < UserGrade.EDITOR.getValue()){
             throw new BusinessException(ExceptionCode.USER_NOT_ALLOWED);
         }
         Request request = requestRepository.findById(reqId).orElseThrow(() -> new BusinessException(ExceptionCode.REQUEST_NOT_FOUND));

--- a/src/main/java/com/example/onlinenews/user/api/UserAPI.java
+++ b/src/main/java/com/example/onlinenews/user/api/UserAPI.java
@@ -1,7 +1,9 @@
 package com.example.onlinenews.user.api;
 
+import com.example.onlinenews.jwt.dto.JwtToken;
 import com.example.onlinenews.user.dto.GeneralSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournalistSignupRequestDTO;
+import com.example.onlinenews.user.dto.LoginRequestDto;
 import com.example.onlinenews.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,5 +34,11 @@ public interface UserAPI {
     @GetMapping("/emailCheck")
     @Operation(summary = "이메일 존재하는지 확인", description = "이메일이 이미 존재하는지 확인합니다. ")
     Boolean emailCheck(@RequestParam String email);
+
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인 메서드", description = "사용자의 아이디, 패스워드를 받아 인증합니다. ")
+    ResponseEntity<JwtToken> login(@RequestBody LoginRequestDto requestDto);
+
 
 }

--- a/src/main/java/com/example/onlinenews/user/controller/UserController.java
+++ b/src/main/java/com/example/onlinenews/user/controller/UserController.java
@@ -2,16 +2,19 @@ package com.example.onlinenews.user.controller;
 
 import com.example.onlinenews.error.BusinessException;
 import com.example.onlinenews.error.ExceptionCode;
+import com.example.onlinenews.jwt.dto.JwtToken;
 import com.example.onlinenews.publisher.service.PublisherService;
 import com.example.onlinenews.user.api.UserAPI;
 import com.example.onlinenews.user.dto.GeneralCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournalistSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournallistCreateRequestDTO;
+import com.example.onlinenews.user.dto.LoginRequestDto;
 import com.example.onlinenews.user.entity.User;
 import com.example.onlinenews.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.RestController;
@@ -88,7 +91,6 @@ public class UserController implements UserAPI {
             user_img = userService.saveProfileImg(requestDTO.getUser_img());
         }
 
-
         String user_pw = passwordEncoder.encode(requestDTO.getUser_pw());
         boolean user_sex = !requestDTO.getUser_sex().equals("F");
 
@@ -108,5 +110,10 @@ public class UserController implements UserAPI {
     @Override
     public Boolean emailCheck(String email){
         return !userService.emailExists(email);
+    }
+
+    @Override
+    public ResponseEntity<JwtToken> login(LoginRequestDto requestDto) {
+        return new ResponseEntity<>(userService.login(requestDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/onlinenews/user/controller/UserController.java
+++ b/src/main/java/com/example/onlinenews/user/controller/UserController.java
@@ -66,6 +66,7 @@ public class UserController implements UserAPI {
         createRequestDTO.setUser_cp(requestDTO.getUser_cp());
         createRequestDTO.setUser_sex(user_sex);
         createRequestDTO.setUser_img(user_img);
+        createRequestDTO.setUser_nickname(requestDTO.getUser_nickname());
 
         userService.createGeneralUser(createRequestDTO);
         return ResponseEntity.ok(createRequestDTO);

--- a/src/main/java/com/example/onlinenews/user/dto/GeneralCreateRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/user/dto/GeneralCreateRequestDTO.java
@@ -11,4 +11,5 @@ public class GeneralCreateRequestDTO {
     private String user_cp;
     private String user_img;
     private Boolean user_sex;
+    private String user_nickname;
 }

--- a/src/main/java/com/example/onlinenews/user/dto/GeneralSignupRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/user/dto/GeneralSignupRequestDTO.java
@@ -12,4 +12,5 @@ public class GeneralSignupRequestDTO {
     private String user_cp;
     private MultipartFile user_img;
     private String user_sex;
+    private String user_nickname;
 }

--- a/src/main/java/com/example/onlinenews/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/onlinenews/user/dto/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.example.onlinenews.user.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/onlinenews/user/entity/User.java
+++ b/src/main/java/com/example/onlinenews/user/entity/User.java
@@ -39,8 +39,9 @@ public class User {
     @Column
     private String img; //프로필 사진
 
+    @Enumerated(EnumType.STRING) // Enum을 문자열로 저장
     @Column(nullable = false)
-    private int grade; //사용자 등급
+    private UserGrade grade; //사용자 등급
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/java/com/example/onlinenews/user/entity/User.java
+++ b/src/main/java/com/example/onlinenews/user/entity/User.java
@@ -54,4 +54,7 @@ public class User {
     @JsonIgnore
     private Publisher publisher;
 
+    @Column
+    private String nickname;
+
 }

--- a/src/main/java/com/example/onlinenews/user/entity/UserGrade.java
+++ b/src/main/java/com/example/onlinenews/user/entity/UserGrade.java
@@ -1,0 +1,20 @@
+package com.example.onlinenews.user.entity;
+
+public enum UserGrade {
+    SYSTEM_ADMIN(9),
+    EDITOR(9),
+    REPORTER(7),
+    INTERN_REPORTER(5),
+    CITIZEN_REPORTER(4),
+    GENERAL_MEMBER(3);
+
+    private final int value;
+
+    UserGrade(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/example/onlinenews/user/service/UserService.java
+++ b/src/main/java/com/example/onlinenews/user/service/UserService.java
@@ -2,23 +2,27 @@ package com.example.onlinenews.user.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.onlinenews.error.BusinessException;
+import com.example.onlinenews.error.ExceptionCode;
+import com.example.onlinenews.jwt.dto.JwtToken;
+import com.example.onlinenews.jwt.provider.JwtTokenProvider;
 import com.example.onlinenews.publisher.service.PublisherService;
 import com.example.onlinenews.user.dto.GeneralCreateRequestDTO;
 import com.example.onlinenews.user.dto.JournallistCreateRequestDTO;
+import com.example.onlinenews.user.dto.LoginRequestDto;
 import com.example.onlinenews.user.entity.User;
 import com.example.onlinenews.user.entity.UserGrade;
 import com.example.onlinenews.user.repository.UserRepository;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.joda.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 
 @Service
@@ -27,31 +31,35 @@ public class UserService {
     private final PublisherService publisherService;
     private final PasswordEncoder passwordEncoder;
     private final AmazonS3 amazonS3;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Value("${cloud.aws.s3.bucket}")
     private String buketName;
 
     @Autowired
-    public UserService(UserRepository userRepository, PublisherService publisherService, PasswordEncoder passwordEncoder, AmazonS3 amazonS3) {
+    public UserService(UserRepository userRepository, PublisherService publisherService,
+                       PasswordEncoder passwordEncoder, AmazonS3 amazonS3,
+                       JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;
         this.publisherService = publisherService;
         this.passwordEncoder = passwordEncoder;
         this.amazonS3 = amazonS3;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    public List<User> getAllUser(){
+    public List<User> getAllUser() {
         return userRepository.findAll();
     }
 
-    public Optional<User> read(Long id){
+    public Optional<User> read(Long id) {
         return userRepository.findById(id);
     }
 
-    public Boolean emailExists(String email){
+    public Boolean emailExists(String email) {
         return userRepository.findByEmail(email).isPresent();
     }
 
-    public void createGeneralUser(GeneralCreateRequestDTO requestDTO){
+    public void createGeneralUser(GeneralCreateRequestDTO requestDTO) {
         User user = User.builder()
                 .email(requestDTO.getUser_email())
                 .pw(requestDTO.getUser_pw())
@@ -67,7 +75,7 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public void createJournalistUser(JournallistCreateRequestDTO requestDTO){
+    public void createJournalistUser(JournallistCreateRequestDTO requestDTO) {
         User user = User.builder()
                 .email(requestDTO.getUser_email())
                 .pw(requestDTO.getUser_pw())
@@ -83,7 +91,7 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public String saveProfileImg(MultipartFile file){
+    public String saveProfileImg(MultipartFile file) {
         String originalFilename = file.getOriginalFilename();
         String fileExtension = "";
         if (originalFilename != null && !originalFilename.isEmpty()) {
@@ -94,11 +102,32 @@ public class UserService {
         String fileUrl = "https://" + buketName + ".s3.amazonaws.com/profileImg/" + uniqueFilename;
 
         try {
-            amazonS3.putObject(new PutObjectRequest(buketName,uniqueFilename,file.getInputStream(),null));
+            amazonS3.putObject(new PutObjectRequest(buketName, uniqueFilename, file.getInputStream(), null));
         } catch (IOException e) {
             throw new RuntimeException("Failed to upload file to S3");
         }
 
         return fileUrl;
+    }
+
+    public JwtToken login(LoginRequestDto requestDto) {
+        User user = userRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPw())) {
+            throw new BusinessException(ExceptionCode.USER_PASSWORD_INCORRECT);
+        }
+
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getEmail());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getEmail());
+        System.out.println("login - token 만들기 : " + accessToken + ", " + refreshToken);
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build()
+                ;
+
     }
 }

--- a/src/main/java/com/example/onlinenews/user/service/UserService.java
+++ b/src/main/java/com/example/onlinenews/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.onlinenews.publisher.service.PublisherService;
 import com.example.onlinenews.user.dto.GeneralCreateRequestDTO;
 import com.example.onlinenews.user.dto.JournallistCreateRequestDTO;
 import com.example.onlinenews.user.entity.User;
+import com.example.onlinenews.user.entity.UserGrade;
 import com.example.onlinenews.user.repository.UserRepository;
 import org.joda.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +62,7 @@ public class UserService {
                 .bio(null)
                 .publisher(null)
                 .createdAt(LocalDateTime.now())
-                .grade(3).build();
+                .grade(UserGrade.GENERAL_MEMBER).build();
 
         userRepository.save(user);
     }
@@ -77,7 +78,7 @@ public class UserService {
                 .bio(null)
                 .publisher(publisherService.getPublisherByName(requestDTO.getPublisher()))
                 .createdAt(LocalDateTime.now())
-                .grade(4).build();
+                .grade(UserGrade.CITIZEN_REPORTER).build();
 
         userRepository.save(user);
     }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## ⭐ User 속성 변경 
### 1. nickname 속성 추가
### 2. grade 타입 int -> UserGrade ENUM 으로 변경 및 이와 관련된 파일 수정 (RequestService 에 해당 부분 수정 완료) 
```
public enum UserGrade {
    SYSTEM_ADMIN(9),
    EDITOR(9),
    REPORTER(7),
    INTERN_REPORTER(5),
    CITIZEN_REPORTER(4),
    GENERAL_MEMBER(3);
}
```
--- 
## 🔔 변경 사항 
### 1.  JWT 토큰 생성, 검증 관련한 클래스 및 Filter 생성
### 2. SecurityConfig 관리자 API 접근 권한 설정 
>  /api/admin/** 으로 시작되는 API들은 관리자(SYSTEM_ADMIN(9))와 편집자(EDITOR(9))만 접근 가능하도록 시큐리티 설정 했습니다 
### 3. 기본 로그인 API 구현 

## ✅ 테스트 결과
### 1.   /api/user/login
<img width="483" alt="image" src="https://github.com/user-attachments/assets/7b8f139b-eb3f-41ee-8f51-60091b1575f5">


### 2. 관리자 계정이 /api/admin/request API 실행 시 접근 가능 
> 디비에 관리자 계정 하나 만들고 돌렸습니다  
<img width="464" alt="image" src="https://github.com/user-attachments/assets/de15cd1b-d347-4dfe-b04f-bc33ce347271">

### 3. 일반 회원 계정이 /api/admin/request API 실행 시 권한 없음 에러 반환
<img width="461" alt="image" src="https://github.com/user-attachments/assets/6c0ff552-ff49-45e9-8cab-4a98ec3f68ec">



## 🔖 관련 이슈
### #20 [feat] Security + JWT 설정 
### #28 [feat] 로그인
