### PR TITLE
Feat/#33 admin signup add : 시스템 관리자, 편집장 계정 생성 API 구현 

### DIFF
--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -17,8 +17,9 @@ public enum ExceptionCode {
     USER_ID_NOT_FOUND(404, "USER_006", "해당되는 id의 사용자를 찾을 수 없습니다."),
     USER_NOT_ALLOWED(404, "USER_007", "편집장 이상만 가능한 작업입니다."),
     USER_PASSWORD_INCORRECT(401, "USER_008", "비밀번호가 틀렸습니다."),
+    INVITE_CODE_MISMATCH(400, "KEY_001", "올바르지 않는 초대코드 입니다."),
 
-    EMAIL_CONFLICT(409, "EMAIL_009","이미 존재하는 email입니다. "),
+    EMAIL_CONFLICT(409, "EMAIL_009", "이미 존재하는 email입니다. "),
 
     REQUEST_NOT_FOUND(404, "REQUEST_001", "해당되는 id 의 요청을 찾을 수 없습니다."),
     ALREADY_APPROVED(400, "REQUEST_002", "이미 '승인' 한 상태입니다."),
@@ -27,11 +28,10 @@ public enum ExceptionCode {
 
 
     NULL_POINT_ERROR(404, "G010", "NullPointerException 발생"),
-    PASSWORD_MISMATCH(400,"PASSWORD_001", "비밀번호 확인이 틀렸습니다."),
+    PASSWORD_MISMATCH(400, "PASSWORD_001", "비밀번호 확인이 틀렸습니다."),
 
     // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
     NOT_VALID_ERROR(404, "G011", "Validation Exception 발생");
-
 
     // 1. status = 날려줄 상태코드
     // 2. code = 해당 오류가 어느부분과 관련있는지 카테고리화 해주는 코드. 예외 원인 식별하기 편하기에 추가

--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -18,7 +18,8 @@ public enum ExceptionCode {
     USER_NOT_ALLOWED(404, "USER_007", "편집장 이상만 가능한 작업입니다."),
     USER_PASSWORD_INCORRECT(401, "USER_008", "비밀번호가 틀렸습니다."),
     INVITE_CODE_MISMATCH(400, "KEY_001", "올바르지 않는 초대코드 입니다."),
-
+    PUBLISHER_NOT_FOUND(404, "PUB_001", "해당 이름의 신문사를 찾을 수 없습니다."),
+    
     EMAIL_CONFLICT(409, "EMAIL_009", "이미 존재하는 email입니다. "),
 
     REQUEST_NOT_FOUND(404, "REQUEST_001", "해당되는 id 의 요청을 찾을 수 없습니다."),

--- a/src/main/java/com/example/onlinenews/user/api/UserAPI.java
+++ b/src/main/java/com/example/onlinenews/user/api/UserAPI.java
@@ -1,16 +1,21 @@
 package com.example.onlinenews.user.api;
 
 import com.example.onlinenews.jwt.dto.JwtToken;
+import com.example.onlinenews.user.dto.AdminCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournalistSignupRequestDTO;
 import com.example.onlinenews.user.dto.LoginRequestDto;
 import com.example.onlinenews.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequestMapping("/api/user")
 @Tag(name = "User", description = "사용자 관련 API")
@@ -28,13 +33,16 @@ public interface UserAPI {
     ResponseEntity<?> generalSignup(@RequestBody GeneralSignupRequestDTO requestDTO);
 
     @PostMapping("/signup/journalist")
-    @Operation(summary = "시민기자 회원가입",description = "시민기자 회원가입을 수행합니다.")
+    @Operation(summary = "시민기자 회원가입", description = "시민기자 회원가입을 수행합니다.")
     ResponseEntity<?> journalistSignup(@RequestBody JournalistSignupRequestDTO requestDTO);
+
+    @PostMapping("/signup/admin")
+    @Operation(summary = "시스템 관리자 계정 생성(회원가입)", description = "시스템 관리자의 회원가입을 수행합니다")
+    ResponseEntity<?> systemAdminSignup(@RequestBody AdminCreateRequestDTO requestDTO);
 
     @GetMapping("/emailCheck")
     @Operation(summary = "이메일 존재하는지 확인", description = "이메일이 이미 존재하는지 확인합니다. ")
     Boolean emailCheck(@RequestParam String email);
-
 
     @PostMapping("/login")
     @Operation(summary = "로그인 메서드", description = "사용자의 아이디, 패스워드를 받아 인증합니다. ")

--- a/src/main/java/com/example/onlinenews/user/api/UserAPI.java
+++ b/src/main/java/com/example/onlinenews/user/api/UserAPI.java
@@ -2,6 +2,7 @@ package com.example.onlinenews.user.api;
 
 import com.example.onlinenews.jwt.dto.JwtToken;
 import com.example.onlinenews.user.dto.AdminCreateRequestDTO;
+import com.example.onlinenews.user.dto.EditorCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournalistSignupRequestDTO;
 import com.example.onlinenews.user.dto.LoginRequestDto;
@@ -39,6 +40,10 @@ public interface UserAPI {
     @PostMapping("/signup/admin")
     @Operation(summary = "시스템 관리자 계정 생성(회원가입)", description = "시스템 관리자의 회원가입을 수행합니다")
     ResponseEntity<?> systemAdminSignup(@RequestBody AdminCreateRequestDTO requestDTO);
+
+    @PostMapping("/signup/editor")
+    @Operation(summary = "편집장 계정 생성(회원가입)", description = "편집장의 회원가입을 수행합니다. ")
+    ResponseEntity<?> editorSignup(@RequestBody EditorCreateRequestDTO requestDTO);
 
     @GetMapping("/emailCheck")
     @Operation(summary = "이메일 존재하는지 확인", description = "이메일이 이미 존재하는지 확인합니다. ")

--- a/src/main/java/com/example/onlinenews/user/controller/UserController.java
+++ b/src/main/java/com/example/onlinenews/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.example.onlinenews.jwt.dto.JwtToken;
 import com.example.onlinenews.publisher.service.PublisherService;
 import com.example.onlinenews.user.api.UserAPI;
 import com.example.onlinenews.user.dto.AdminCreateRequestDTO;
+import com.example.onlinenews.user.dto.EditorCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournalistSignupRequestDTO;
@@ -118,6 +119,21 @@ public class UserController implements UserAPI {
         if (userService.checkSecreteKey(GRADE, inviteCode)) {
             userService.createAdminUser(id, pw, GRADE, "");
             return ResponseEntity.ok("ADMIN 계정 생성이 완료되었습니다");
+        }
+        throw new BusinessException(ExceptionCode.INVITE_CODE_MISMATCH);
+    }
+
+    @Override
+    public ResponseEntity<?> editorSignup(EditorCreateRequestDTO requestDTO) {
+        String id = requestDTO.getId();
+        String pw = requestDTO.getPassword();
+        String inviteCode = requestDTO.getInviteCode();
+        String publisherName = requestDTO.getPublisherName();
+
+        UserGrade GRADE = UserGrade.EDITOR;
+        if (userService.checkSecreteKey(GRADE, inviteCode)) {
+            userService.createAdminUser(id, pw, GRADE, publisherName);
+            return ResponseEntity.ok("EDITOR 계정 생성이 완료되었습니다");
         }
         throw new BusinessException(ExceptionCode.INVITE_CODE_MISMATCH);
     }

--- a/src/main/java/com/example/onlinenews/user/controller/UserController.java
+++ b/src/main/java/com/example/onlinenews/user/controller/UserController.java
@@ -5,23 +5,24 @@ import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.jwt.dto.JwtToken;
 import com.example.onlinenews.publisher.service.PublisherService;
 import com.example.onlinenews.user.api.UserAPI;
+import com.example.onlinenews.user.dto.AdminCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralCreateRequestDTO;
 import com.example.onlinenews.user.dto.GeneralSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournalistSignupRequestDTO;
 import com.example.onlinenews.user.dto.JournallistCreateRequestDTO;
 import com.example.onlinenews.user.dto.LoginRequestDto;
 import com.example.onlinenews.user.entity.User;
+import com.example.onlinenews.user.entity.UserGrade;
 import com.example.onlinenews.user.service.UserService;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,17 +40,17 @@ public class UserController implements UserAPI {
 
     @Override
     public User read(Long id) {
-        Optional<User> user =  userService.read(id);
+        Optional<User> user = userService.read(id);
         return user.orElseThrow(() -> new NoSuchElementException("User not found"));
     }
 
     @Override
     public ResponseEntity<?> generalSignup(GeneralSignupRequestDTO requestDTO) {
-        if(userService.emailExists(requestDTO.getUser_email())){
+        if (userService.emailExists(requestDTO.getUser_email())) {
             throw new BusinessException(ExceptionCode.EMAIL_CONFLICT);
         }
 
-        if(!requestDTO.getUser_pw().equals(requestDTO.getUser_pw2())){
+        if (!requestDTO.getUser_pw().equals(requestDTO.getUser_pw2())) {
             throw new BusinessException(ExceptionCode.PASSWORD_MISMATCH);
         }
 
@@ -77,11 +78,11 @@ public class UserController implements UserAPI {
 
     @Override
     public ResponseEntity<?> journalistSignup(JournalistSignupRequestDTO requestDTO) {
-        if(userService.emailExists(requestDTO.getUser_email())){
+        if (userService.emailExists(requestDTO.getUser_email())) {
             throw new BusinessException(ExceptionCode.EMAIL_CONFLICT);
         }
 
-        if(!requestDTO.getUser_pw().equals(requestDTO.getUser_pw2())){
+        if (!requestDTO.getUser_pw().equals(requestDTO.getUser_pw2())) {
             throw new BusinessException(ExceptionCode.PASSWORD_MISMATCH);
         }
 
@@ -108,7 +109,22 @@ public class UserController implements UserAPI {
     }
 
     @Override
-    public Boolean emailCheck(String email){
+    public ResponseEntity<?> systemAdminSignup(AdminCreateRequestDTO requestDTO) {
+        String id = requestDTO.getId();
+        String pw = requestDTO.getPassword();
+        String inviteCode = requestDTO.getInviteCode();
+
+        UserGrade GRADE = UserGrade.SYSTEM_ADMIN;
+        if (userService.checkSecreteKey(GRADE, inviteCode)) {
+            userService.createAdminUser(id, pw, GRADE, "");
+            return ResponseEntity.ok("ADMIN 계정 생성이 완료되었습니다");
+        }
+        throw new BusinessException(ExceptionCode.INVITE_CODE_MISMATCH);
+    }
+
+
+    @Override
+    public Boolean emailCheck(String email) {
         return !userService.emailExists(email);
     }
 

--- a/src/main/java/com/example/onlinenews/user/dto/AdminCreateRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/user/dto/AdminCreateRequestDTO.java
@@ -1,0 +1,10 @@
+package com.example.onlinenews.user.dto;
+
+import lombok.Data;
+
+@Data
+public class AdminCreateRequestDTO {
+    private String id;
+    private String password;
+    private String inviteCode;
+}

--- a/src/main/java/com/example/onlinenews/user/dto/EditorCreateRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/user/dto/EditorCreateRequestDTO.java
@@ -1,0 +1,11 @@
+package com.example.onlinenews.user.dto;
+
+import lombok.Data;
+
+@Data
+public class EditorCreateRequestDTO {
+    private String id;
+    private String password;
+    private String inviteCode;
+    private String publisherName;
+}

--- a/src/main/java/com/example/onlinenews/user/dto/GeneralCreateRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/user/dto/GeneralCreateRequestDTO.java
@@ -1,7 +1,6 @@
 package com.example.onlinenews.user.dto;
 
 import lombok.Data;
-import org.springframework.web.multipart.MultipartFile;
 
 @Data
 public class GeneralCreateRequestDTO {

--- a/src/main/java/com/example/onlinenews/user/service/UserService.java
+++ b/src/main/java/com/example/onlinenews/user/service/UserService.java
@@ -151,6 +151,10 @@ public class UserService {
         Publisher publisher = null;
         if (!publisherName.isEmpty() || !publisherName.isBlank()) {
             publisher = publisherService.getPublisherByName(publisherName);
+
+            if (publisher == null) {
+                throw new BusinessException(ExceptionCode.PUBLISHER_NOT_FOUND);
+            }
         }
 
         User user = User.builder()

--- a/src/main/java/com/example/onlinenews/user/service/UserService.java
+++ b/src/main/java/com/example/onlinenews/user/service/UserService.java
@@ -157,14 +157,19 @@ public class UserService {
             }
         }
 
+        String setString = "ADMIN";
+        if (userGrade.equals(UserGrade.EDITOR)) {
+            setString = "EDITOR";
+        }
+
         User user = User.builder()
                 .email(id)
                 .pw(passwordEncoder.encode(password))
                 .grade(userGrade)
                 .sex(true) // 관리자의 나머지 계정 정보의 나머지값들에 "ADMIN" 이 들어가도록 설정
-                .cp("ADMIN")
-                .name("ADMIN")
-                .nickname("ADMIN")
+                .cp(setString)
+                .name(setString)
+                .nickname(setString)
                 .publisher(publisher)
                 .createdAt(LocalDateTime.now())
                 .build();


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1.   시스템 관리자 (SYSTEM_ADMIN) 계정 생성 기능 구현
### 2.  신문사 편집장(EDITOR) 계정 생성 기능 구현 
### 3.  application.yml 수정 (시크릿 키 추가) 

## ✅ 테스트 결과
### 1.   /api/user/signup/admin : 시스템 관리자 계정 생성 
> requestbody : id(아이디/이메일), password(비밀번호), inviteCode(초대코드) 

**1) 요청** 
<img width="370" alt="시스템 관리자 회원가입 요청" src="https://github.com/user-attachments/assets/a845a619-8c2f-485a-8648-12d615d1df09">

**2) 응답** 
<img width="353" alt="시스템 관리자 회원가입 응답 " src="https://github.com/user-attachments/assets/548fe5ec-a39d-4b6e-b123-1a425979e5a7">

**3) 생성한 관리자 계정으로 로그인 후 /api/admin/request 호출 결과** 
> 시큐리티에 시스템 관리자만 접근하도록 설정한 API 호출 테스트

<img width="385" alt="시스템 관리자 로그인" src="https://github.com/user-attachments/assets/947564c6-cdd3-4b4f-a841-23697a2f2c22">

<img width="424" alt="시스템 관리자 로그인 후 인증 테스트 " src="https://github.com/user-attachments/assets/8bff0076-d6e3-4c16-bf16-fe2527e749e5">

### 2. /api/user/signup/editor :  신문사 편집장 계정 생성
> requestbody : id(아이디/이메일), password(비밀번호), inviteCode(초대코드) , publisher(신문사 이름)

**◻️ 테스트 전 publisher 디비 상태(수동으로 테스트 데이터 넣었음)**
<img width="341" alt="image" src="https://github.com/user-attachments/assets/02b88feb-4ecb-4cab-bb01-bac0a8e29919">

**1) 존재하는 신문사를 넣어 편집자 계정 생성 할 때** 
<img width="458" alt="편집장 회원가입 테스트(신문사가 존재할때)" src="https://github.com/user-attachments/assets/e4d1b6ed-f5e8-4653-9c34-84906cd74cce">

**2) 존재하지 않는 신문사를 넣어 편집자 계정 생성 할 때** 
<img width="370" alt="편집장 회원가입 테스트(신문사가 없을때) 요청" src="https://github.com/user-attachments/assets/2f7ee4c1-7c74-428e-99e7-d891bc6753a0">

<img width="347" alt="편집장 회원가입 테스트(신문사가 없을때) 응답" src="https://github.com/user-attachments/assets/3397a305-0836-42e9-8deb-6862dce224cc">


## 🔖 관련 이슈
### #33 [feat] 관리자, 편집장 회원가입 API 개발 
