### PR TITLE
Feat/#18 admin request

### DIFF
--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -11,6 +11,7 @@ import com.example.onlinenews.error.BusinessException;
 import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.notification.service.NotificationService;
 import com.example.onlinenews.request.entity.RequestStatus;
+import com.example.onlinenews.request.service.RequestService;
 import com.example.onlinenews.user.entity.User;
 import com.example.onlinenews.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final NotificationService notificationService;
     private final UserRepository userRepository;
-
+    private final RequestService requestService;
 
     // 기사 작성
     public ResponseEntity<ArticleResponseDTO> createArticle(ArticleRequestDTO requestDTO, String email) {
@@ -47,7 +48,7 @@ public class ArticleService {
                 .build();
 
         Article savedArticle = articleRepository.save(article);
-
+        requestService.create(user, savedArticle);
         return ResponseEntity.ok(convertToResponseDTO(savedArticle));
     }
 

--- a/src/main/java/com/example/onlinenews/request/api/RequestApi.java
+++ b/src/main/java/com/example/onlinenews/request/api/RequestApi.java
@@ -23,7 +23,7 @@ public interface RequestApi {
     @Operation(summary = "요청 id로 요청 조회", description = "요청아이디(path)로 해당 요청을 조회합니다.")
     RequestDto read(@PathVariable Long reqId);
 
-    @PatchMapping("/{reqId}/accept")
+    @PatchMapping("/{reqId}/approve")
     @Operation(summary = "요청 수락", description = "편집장이 id에 해당하는 요청을 수락합니다.")
     ResponseEntity<?> requestAccept(HttpServletRequest request, @PathVariable Long reqId);
 

--- a/src/main/java/com/example/onlinenews/request/api/RequestApi.java
+++ b/src/main/java/com/example/onlinenews/request/api/RequestApi.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RequestMapping("/api/admin/request")
+@RequestMapping("/api/request")
 @Tag(name = "Request", description = "요청 API")
 public interface RequestApi {
 

--- a/src/main/java/com/example/onlinenews/request/api/RequestApi.java
+++ b/src/main/java/com/example/onlinenews/request/api/RequestApi.java
@@ -38,6 +38,6 @@ public interface RequestApi {
 
     @GetMapping("/status")
     @Operation(summary = "상태별로 요청 조회", description = "상태를 입력(param)하여 해당 상태의 요청들을 조회합니다.")
-    List<RequestDto> getByStatus(@RequestParam String keyword);
+    List<RequestDto> getByStatus(HttpServletRequest request, @RequestParam String keyword);
 
 }

--- a/src/main/java/com/example/onlinenews/request/api/RequestApi.java
+++ b/src/main/java/com/example/onlinenews/request/api/RequestApi.java
@@ -16,8 +16,8 @@ import java.util.List;
 public interface RequestApi {
 
     @GetMapping("")
-    @Operation(summary = "전체 요청 조회", description = "전체 요청 목록을 조회합니다.")
-    List<RequestDto> list();
+    @Operation(summary = "소속 직원 요청 조회", description = "편집장 밑에 소속된 직원들의 요청을 조회합니다")
+    List<RequestDto> getByPublisher(HttpServletRequest request);
 
     @GetMapping("/{reqId}")
     @Operation(summary = "요청 id로 요청 조회", description = "요청아이디(path)로 해당 요청을 조회합니다.")
@@ -39,4 +39,5 @@ public interface RequestApi {
     @GetMapping("/status")
     @Operation(summary = "상태별로 요청 조회", description = "상태를 입력(param)하여 해당 상태의 요청들을 조회합니다.")
     List<RequestDto> getByStatus(@RequestParam String keyword);
+
 }

--- a/src/main/java/com/example/onlinenews/request/controller/RequestController.java
+++ b/src/main/java/com/example/onlinenews/request/controller/RequestController.java
@@ -22,8 +22,9 @@ public class RequestController implements RequestApi {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public List<RequestDto> list() {
-        return requestService.list();
+    public List<RequestDto> getByPublisher(HttpServletRequest request) {
+        String email = jwtTokenProvider.getAccount(jwtTokenProvider.resolveToken(request));
+        return requestService.getRequestsForEditor(email);
     }
 
     @Override

--- a/src/main/java/com/example/onlinenews/request/controller/RequestController.java
+++ b/src/main/java/com/example/onlinenews/request/controller/RequestController.java
@@ -51,8 +51,9 @@ public class RequestController implements RequestApi {
     }
 
     @Override
-    public List<RequestDto> getByStatus(String keyword) {
-        return requestService.getByStatus(keyword);
+    public List<RequestDto> getByStatus(HttpServletRequest request, String keyword) {
+        String email = jwtTokenProvider.getAccount(jwtTokenProvider.resolveToken(request));
+        return requestService.getByStatus(email, keyword);
     }
 
 }

--- a/src/main/java/com/example/onlinenews/request/repository/RequestRepository.java
+++ b/src/main/java/com/example/onlinenews/request/repository/RequestRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Repository
 public interface RequestRepository  extends JpaRepository<Request, Long> {
-    List<Request> findRequestsByStatus(RequestStatus requestStatus);
+    List<Request> findByArticleUserPublisherAndStatus(Publisher publisher, RequestStatus requestStatus);
 
     List<Request> findByArticleUserPublisher(Publisher publisher);
 }

--- a/src/main/java/com/example/onlinenews/request/repository/RequestRepository.java
+++ b/src/main/java/com/example/onlinenews/request/repository/RequestRepository.java
@@ -1,5 +1,6 @@
 package com.example.onlinenews.request.repository;
 
+import com.example.onlinenews.publisher.entity.Publisher;
 import com.example.onlinenews.request.entity.Request;
 import com.example.onlinenews.request.entity.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import java.util.List;
 @Repository
 public interface RequestRepository  extends JpaRepository<Request, Long> {
     List<Request> findRequestsByStatus(RequestStatus requestStatus);
+
+    List<Request> findByArticleUserPublisher(Publisher publisher);
 }

--- a/src/main/java/com/example/onlinenews/request/service/RequestService.java
+++ b/src/main/java/com/example/onlinenews/request/service/RequestService.java
@@ -1,6 +1,7 @@
 package com.example.onlinenews.request.service;
 
-import com.example.onlinenews.article.service.ArticleService;
+import com.example.onlinenews.article.entity.Article;
+import com.example.onlinenews.article.repository.ArticleRepository;
 import com.example.onlinenews.error.BusinessException;
 import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.request.dto.RequestCommentDto;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,7 +25,7 @@ import java.util.stream.Collectors;
 public class RequestService {
     private final RequestRepository requestRepository;
     private final UserRepository userRepository;
-    private final ArticleService articleService;
+    private final ArticleRepository articleRepository;
 
     //전체 조회
     public List<RequestDto> list(){
@@ -39,20 +41,16 @@ public class RequestService {
     }
 
     //요청 생성 (article 생성 시 주석 해제)
-//    public RequestDto create(RequestCreateDto createDto){
-//        User user = userRepository.findById(createDto.getUserId()).orElseThrow(() -> new  BusinessException(ExceptionCode.USER_NOT_FOUND));
-//        Article article = articleRepository.findById(createDto.getArticleId()).orElseThrow(() -> new BusinessException(ExceptionCode.ARTICLE_NOT_FOUND));
-////
-//        Request request  = Request.builder()
-//                .user(user)
-//                .article(article)
-//                .createdAt(LocalDateTime.now())
-//                .statue(RequestStatus.PENDING)
-//                .build();
-//
-//        requestRepository.save(request);
-//        return RequestDto.fromEntity(request);
-//    }
+    public RequestDto create(User user, Article article){
+        Request request  = Request.builder()
+                .user(user)
+                .article(article)
+                .createdAt(LocalDateTime.now())
+                .status(RequestStatus.PENDING)
+                .build();
+        requestRepository.save(request);
+        return RequestDto.fromEntity(request);
+    }
 
     //요청 수락
     @Transactional
@@ -68,8 +66,7 @@ public class RequestService {
         request.updateStatus(RequestStatus.APPROVED, null);
 
         //기사 상태 업데이트
-        Long articleId = request.getArticle().getId();
-        articleService.statusUpdate(articleId, request.getStatus());
+        request.getArticle().updateStatue(request.getStatus());
 
         return request.getStatus();
     }
@@ -89,9 +86,7 @@ public class RequestService {
         String comment = requestCommentDto.getComment();
         request.updateStatus(RequestStatus.HOLDING, comment);
 
-        //기사 상태 업데이트
-        Long articleId = request.getArticle().getId();
-        articleService.statusUpdate(articleId, request.getStatus());
+        request.getArticle().updateStatue(request.getStatus());
 
         return request.getStatus();
     }
@@ -110,10 +105,7 @@ public class RequestService {
         String comment = requestCommentDto.getComment();
         request.updateStatus(RequestStatus.REJECTED, comment);
 
-        //기사 상태 업데이트
-        Long articleId = request.getArticle().getId();
-        articleService.statusUpdate(articleId, request.getStatus());
-
+        request.getArticle().updateStatue(request.getStatus());
         return request.getStatus();
     }
 

--- a/src/main/java/com/example/onlinenews/request/service/RequestService.java
+++ b/src/main/java/com/example/onlinenews/request/service/RequestService.java
@@ -4,6 +4,8 @@ import com.example.onlinenews.article.entity.Article;
 import com.example.onlinenews.article.repository.ArticleRepository;
 import com.example.onlinenews.error.BusinessException;
 import com.example.onlinenews.error.ExceptionCode;
+import com.example.onlinenews.publisher.entity.Publisher;
+import com.example.onlinenews.publisher.repository.PublisherRepository;
 import com.example.onlinenews.request.dto.RequestCommentDto;
 import com.example.onlinenews.request.dto.RequestDto;
 import com.example.onlinenews.request.entity.Request;
@@ -25,14 +27,6 @@ import java.util.stream.Collectors;
 public class RequestService {
     private final RequestRepository requestRepository;
     private final UserRepository userRepository;
-    private final ArticleRepository articleRepository;
-
-    //전체 조회
-    public List<RequestDto> list(){
-        return requestRepository.findAll().stream()
-                .map(RequestDto::fromEntity)
-                .collect(Collectors.toList());
-    }
 
     //request id로 개별 조회
     public RequestDto read(Long reqId){
@@ -40,7 +34,7 @@ public class RequestService {
         return RequestDto.fromEntity(request);
     }
 
-    //요청 생성 (article 생성 시 주석 해제)
+    //요청 생성
     public RequestDto create(User user, Article article){
         Request request  = Request.builder()
                 .user(user)
@@ -124,5 +118,19 @@ public class RequestService {
                 .map(RequestDto::fromEntity)
                 .collect(Collectors.toList());
     }
+
+    //편집장의 출판사 소속 직원들의 요청 확인
+    public List<RequestDto> getRequestsForEditor(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+        if(user.getGrade().getValue() < UserGrade.EDITOR.getValue()){
+            throw new BusinessException(ExceptionCode.USER_NOT_ALLOWED);
+        }
+
+        return requestRepository.findByArticleUserPublisher( user.getPublisher()).stream()
+                .map(RequestDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+
 
 }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [x]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
1. 기사 작성 시 request 생성 메소드 구현
2. 편집장이 소속 기자들의 요청만 조회하도록 구현
> `findByArticleUserPublisher`

3. 편집장이 소속 기자들의 요청들을 상태별로 조회하도록 구현
>  `findByArticleUserPublisherAndStatus`
4. 기존 전체 조회 list 기능 삭제
5. articleService에서 상태 수정 메소드 제거, requestService에서 직접 수정하도록 수정   
6. 엔드포인트 api/admin/request -> api/request로 수정

## ✅ 테스트 결과
1. 소속 직원 요청만 조회
![스크린샷 2024-11-05 233817](https://github.com/user-attachments/assets/e5e05e0f-adf5-4661-8d30-08566d71e457)
![스크린샷 2024-11-05 233834](https://github.com/user-attachments/assets/7c25396f-ad26-400d-b296-8685f1cfd68f)

2. 소속 직원 요청를 상태별로 조회   
![스크린샷 2024-11-05 235308](https://github.com/user-attachments/assets/f50e0e04-199d-4849-9400-29d3e461a106)
![스크린샷 2024-11-05 235245](https://github.com/user-attachments/assets/4c1dba72-417a-4ec2-9236-36a3acf2a677)

## 🔖 관련 이슈
### #18 [feat] 편집장
