### PR TITLE
Feat/#43 article 이미지 업로드

### DIFF
--- a/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
+++ b/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
@@ -7,8 +7,10 @@ import com.example.onlinenews.article.entity.Category;
 import com.example.onlinenews.request.entity.RequestStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -18,7 +20,9 @@ public interface ArticleAPI {
 
     @PostMapping("write")
     @Operation(summary = "기사 작성", description = "새 기사를 작성합니다.")
-    ResponseEntity<ArticleResponseDTO> createArticle(@RequestBody ArticleRequestDTO requestDTO, @RequestParam String email);
+    public ResponseEntity<ArticleResponseDTO> createArticle( HttpServletRequest httpServletRequest,
+                                                             @RequestPart("requestDTO") ArticleRequestDTO requestDTO,
+                                                             @RequestPart("images") List<MultipartFile> images) ;
 
     @GetMapping("selectAll")
     @Operation(summary = "기사 목록 조회", description = "모든 기사를 조회합니다.")

--- a/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
+++ b/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
@@ -20,7 +20,7 @@ public interface ArticleAPI {
 
     @PostMapping("write")
     @Operation(summary = "기사 작성", description = "새 기사를 작성합니다.")
-    public ResponseEntity<ArticleResponseDTO> createArticle( HttpServletRequest httpServletRequest,
+    public ResponseEntity<?> createArticle( HttpServletRequest httpServletRequest,
                                                              @RequestPart("requestDTO") ArticleRequestDTO requestDTO,
                                                              @RequestPart(value = "images", required = false) List<MultipartFile> images) ;
 

--- a/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
+++ b/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
@@ -22,7 +22,7 @@ public interface ArticleAPI {
     @Operation(summary = "기사 작성", description = "새 기사를 작성합니다.")
     public ResponseEntity<ArticleResponseDTO> createArticle( HttpServletRequest httpServletRequest,
                                                              @RequestPart("requestDTO") ArticleRequestDTO requestDTO,
-                                                             @RequestPart("images") List<MultipartFile> images) ;
+                                                             @RequestPart(value = "images", required = false) List<MultipartFile> images) ;
 
     @GetMapping("selectAll")
     @Operation(summary = "기사 목록 조회", description = "모든 기사를 조회합니다.")

--- a/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
+++ b/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
@@ -8,9 +8,12 @@ import com.example.onlinenews.article.entity.Category;
 import com.example.onlinenews.request.api.RequestApi;
 import com.example.onlinenews.request.entity.RequestStatus;
 import com.example.onlinenews.article.service.ArticleService;
+import com.example.onlinenews.user.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -18,12 +21,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ArticleController implements ArticleAPI {
     private final ArticleService articleService;
+    private final AuthService authService;
 
     // 기사 작성
     @Override
-    public ResponseEntity<ArticleResponseDTO> createArticle(@RequestBody ArticleRequestDTO requestDTO, @RequestParam String email) {
-        return articleService.createArticle(requestDTO, email);
+    public ResponseEntity<ArticleResponseDTO> createArticle(HttpServletRequest httpServletRequest,
+                                                            @RequestPart("requestDTO") ArticleRequestDTO requestDTO,
+                                                            @RequestPart("images") List<MultipartFile> images) {
+        String email = authService.getEmailFromToken(httpServletRequest);
+        return articleService.createArticle(requestDTO, email, images);
     }
+
 
     // 전체 기사 조회
     @Override

--- a/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
+++ b/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
@@ -26,8 +26,8 @@ public class ArticleController implements ArticleAPI {
     // 기사 작성
     @Override
     public ResponseEntity<ArticleResponseDTO> createArticle(HttpServletRequest httpServletRequest,
-                                                            @RequestPart("requestDTO") ArticleRequestDTO requestDTO,
-                                                            @RequestPart("images") List<MultipartFile> images) {
+                                                            ArticleRequestDTO requestDTO,
+                                                            List<MultipartFile> images) {
         String email = authService.getEmailFromToken(httpServletRequest);
         return articleService.createArticle(requestDTO, email, images);
     }

--- a/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
+++ b/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
@@ -25,7 +25,7 @@ public class ArticleController implements ArticleAPI {
 
     // 기사 작성
     @Override
-    public ResponseEntity<ArticleResponseDTO> createArticle(HttpServletRequest httpServletRequest,
+    public ResponseEntity<?> createArticle(HttpServletRequest httpServletRequest,
                                                             ArticleRequestDTO requestDTO,
                                                             List<MultipartFile> images) {
         String email = authService.getEmailFromToken(httpServletRequest);

--- a/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
@@ -17,5 +17,4 @@ public class ArticleRequestDTO {
     private String title;
     private String subtitle;
     private String content;
-    private Boolean isPublic;
 }

--- a/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
@@ -1,11 +1,12 @@
 package com.example.onlinenews.article.dto;
 
 import com.example.onlinenews.article.entity.Category;
-import com.example.onlinenews.request.entity.RequestStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/example/onlinenews/article/entity/Article.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Article.java
@@ -31,7 +31,6 @@ public class Article {
     private User user; 
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Category category;
 
     @Column

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -80,10 +80,10 @@ public class ArticleService {
             }
 
             String uniqueFilename = UUID.randomUUID() + fileExtension;
-            String fileUrl = "https://" + bucketName + ".s3.amazonaws.com/profileImg/" + uniqueFilename;
+            String fileUrl = "https://" + bucketName + ".s3.amazonaws.com/articleImg/" + uniqueFilename;
 
             try {
-                amazonS3.putObject(new PutObjectRequest(bucketName, "profileImg/" + uniqueFilename, file.getInputStream(), null));
+                amazonS3.putObject(new PutObjectRequest(bucketName, "articleImg/" + uniqueFilename, file.getInputStream(), null));
             } catch (IOException e) {
                 throw new RuntimeException("Failed to upload file to S3");
             }

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -1,5 +1,7 @@
 package com.example.onlinenews.article.service;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.onlinenews.article.dto.ArticleRequestDTO;
 import com.example.onlinenews.article.dto.ArticleResponseDTO;
 import com.example.onlinenews.article.dto.ArticleUpdateRequestDTO;
@@ -7,20 +9,26 @@ import com.example.onlinenews.article.entity.Article;
 import com.example.onlinenews.article.entity.Category;
 import com.example.onlinenews.article.repository.ArticleRepository;
 import com.example.onlinenews.article_img.entity.ArticleImg;
+import com.example.onlinenews.article_img.repository.ArticleImgRepository;
 import com.example.onlinenews.error.BusinessException;
 import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.notification.service.NotificationService;
 import com.example.onlinenews.request.entity.RequestStatus;
-import com.example.onlinenews.request.service.RequestService;
 import com.example.onlinenews.user.entity.User;
 import com.example.onlinenews.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,13 +37,21 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final NotificationService notificationService;
     private final UserRepository userRepository;
-    private final RequestService requestService;
+
+    @Autowired
+    private final AmazonS3 amazonS3;
+    private final ArticleImgRepository articleImgRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
 
     // 기사 작성
-    public ResponseEntity<ArticleResponseDTO> createArticle(ArticleRequestDTO requestDTO, String email) {
+    public ResponseEntity<ArticleResponseDTO> createArticle(ArticleRequestDTO requestDTO, String email, List<MultipartFile> images) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
 
+        // Article 엔티티 생성
         Article article = Article.builder()
                 .user(user)
                 .category(requestDTO.getCategory())
@@ -47,12 +63,48 @@ public class ArticleService {
                 .isPublic(requestDTO.getIsPublic())
                 .build();
 
+        // Article을 먼저 저장하여 ID를 생성
         Article savedArticle = articleRepository.save(article);
-        requestService.create(user, savedArticle);
+
+        // 이미지 업로드 및 ArticleImg 엔티티 생성
+        List<ArticleImg> articleImgs = new ArrayList<>();
+        for (MultipartFile file : images) {
+            if (file.isEmpty()) {
+                throw new IllegalArgumentException("파일이 비어 있습니다.");
+            }
+            String originalFilename = file.getOriginalFilename();
+            String fileExtension = "";
+
+            if (originalFilename != null && !originalFilename.isEmpty()) {
+                fileExtension = "." + originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
+            }
+
+            String uniqueFilename = UUID.randomUUID() + fileExtension;
+            String fileUrl = "https://" + bucketName + ".s3.amazonaws.com/profileImg/" + uniqueFilename;
+
+            try {
+                amazonS3.putObject(new PutObjectRequest(bucketName, "profileImg/" + uniqueFilename, file.getInputStream(), null));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to upload file to S3");
+            }
+
+            // S3 URL을 ArticleImg 엔티티에 저장
+            ArticleImg articleImg = ArticleImg.builder()
+                    .article(savedArticle)
+                    .imgUrl(fileUrl)
+                    .build();
+            articleImgs.add(articleImg);
+        }
+
+        // ArticleImg 엔티티 저장
+        articleImgRepository.saveAll(articleImgs);
+
         return ResponseEntity.ok(convertToResponseDTO(savedArticle));
     }
 
+
     // 기사 목록 조회
+    @Transactional
     public ResponseEntity<List<ArticleResponseDTO>> getAllArticles() {
         List<Article> articles = articleRepository.findAll();
 
@@ -65,6 +117,7 @@ public class ArticleService {
 
 
     // 기사 상세 조회
+    @Transactional
     public ResponseEntity<ArticleResponseDTO> getArticleById(Long id) {
         incrementViewCount(id); // 조회수 증가
         Article article = articleRepository.findById(id)
@@ -73,6 +126,7 @@ public class ArticleService {
     }
 
     // 카테고리 별 기사 목록 조회
+    @Transactional
     public ResponseEntity<List<ArticleResponseDTO>> listArticlesByCategory(Category category) {
         List<Article> articles = articleRepository.findByCategory(category);
         List<ArticleResponseDTO> responseDTOS = articles.stream()
@@ -83,6 +137,7 @@ public class ArticleService {
     }
 
     // 제목 또는 내용을 포함하는 기사 목록 조회
+    @Transactional
     public ResponseEntity<List<ArticleResponseDTO>> searchArticles(String title, String content) {
         List<Article> articles = articleRepository.findByTitleContainingOrContentContaining(title, content);
         List<ArticleResponseDTO> responseDTOs = articles.stream()
@@ -92,6 +147,7 @@ public class ArticleService {
     }
 
     // 사용자 ID로 기사 목록 조회
+    @Transactional
     public ResponseEntity<List<ArticleResponseDTO>> getArticlesByUserId(Long userId) {
         List<Article> articles = articleRepository.findByUserId(userId);
         List<ArticleResponseDTO> responseDTOs = articles.stream()
@@ -101,6 +157,7 @@ public class ArticleService {
     }
 
     // 공개된 기사 목록 조회
+    @Transactional
     public ResponseEntity<List<ArticleResponseDTO>> getPublicArticles() {
         List<Article> articles = articleRepository.findByIsPublicTrue();
         List<ArticleResponseDTO> responseDTOs = articles.stream()
@@ -110,6 +167,7 @@ public class ArticleService {
     }
 
     // 상태에 따른 기사 목록 조회
+    @Transactional
     public ResponseEntity<List<ArticleResponseDTO>> getArticlesByState(RequestStatus state) {
         List<Article> articles = articleRepository.findByState(state); // 상태에 따라 기사 조회
         List<ArticleResponseDTO> responseDTOs = articles.stream()
@@ -119,6 +177,7 @@ public class ArticleService {
     }
 
     // 기사 수정
+    @Transactional
     public ResponseEntity<ArticleResponseDTO> updateArticle(Long id, ArticleUpdateRequestDTO updateRequest) {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.ARTICLE_NOT_FOUND));
@@ -165,7 +224,6 @@ public class ArticleService {
     public void create(){
         notificationService.createRequestNoti(2L,2L);
     }
-
 
 
     private ArticleResponseDTO convertToResponseDTO(Article article) {

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -59,7 +59,7 @@ public class ArticleService {
                 .content(requestDTO.getContent())
                 .state(RequestStatus.PENDING)
                 .createdAt(LocalDateTime.now())
-                .isPublic(requestDTO.getIsPublic())
+                .isPublic(false)
                 .build();
 
         // Article을 먼저 저장하여 ID를 생성

--- a/src/main/java/com/example/onlinenews/article_img/repository/ArticleImgRepository.java
+++ b/src/main/java/com/example/onlinenews/article_img/repository/ArticleImgRepository.java
@@ -1,0 +1,7 @@
+package com.example.onlinenews.article_img.repository;
+
+import com.example.onlinenews.article_img.entity.ArticleImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleImgRepository extends JpaRepository<ArticleImg, Long> {
+}

--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -40,7 +40,10 @@ public enum ExceptionCode {
     SUB_NOT_MATCH_USER(400, "MATCH_001", "현재 구독 사용자와 일치하지 않습니다."),
 
     // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
-    NOT_VALID_ERROR(404, "G011", "Validation Exception 발생");
+    NOT_VALID_ERROR(404, "G011", "Validation Exception 발생"),
+
+    S3_UPLOAD_FAILED( 500, "Article_002", "이미지 업로드에 실패했습니다."),
+    FILE_NOT_FOUND(400, "Article_001", "존재하지 않는 파일입니다.");
 
 
 


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [x]  build : 빌드 관련 파일 수정
- [x]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1. user token get
### 2. 이미지 업로드
### 3. 이미지 request를 위한 servlet 설정
### 4. 이미지 없는 경우 로직 추가
### 5. 에러 메시지, 성공 메시지 처리

## ✅ 테스트 결과 
https://github.com/MetalRoze/OnlineNews_BE/pull/47

## 🥹 회고
### 1. 기사 작성자(기자 ID) 저장 방식
처음에는 로그인 시 프론트에서 유저 정보를 session storage에 저장해 두고, API 호출 시에 ID를 params로 전송할 수 있도록 서비스/컨트롤러를 구성했었다. 하지만 다른 팀원들이 헤더로 보내길래 나도 이렇게 바꿔봄
> api 헤더에 로그인 토큰을 담아 백엔드로 요청하면,  서비스 코드에서 토큰으로 유저의 이메일을 찾아 DB에 저장함

### 2. "error": "Unsupported Media Type"
이미지를 여러장 받아와야 해 text 데이터(제목, 소제목, 컨텐츠, ...)와 이미지를 따로 받아야 했는데, 이때 content-type을 모두 MultipartFile로 설정하는 바람에 에러가 발생했다.
> text 데이터는 application/json으로, 이미지는 MultipartFile/form-data로 보내 해결

### 3. 이미지 크기
이미지를 여러장 넣어 request했더니 용량이 크다고 에러남. yml에 최대 용량 키워서 해결했다. 이 정도 용량이 충분한 건진 모르겠어서 나중에 프론트에서 테스트해 봐야 할 듯
```
  servlet:
    multipart:
      enabled: true
      max-file-size: 10MB
      max-request-size: 10MB
```

### 4. Amazon S3; Status Code: 403; Error Code: AccessDenied; 
계속 이게 떠서 .. 너무 괴로웠다..... 검색하면 버킷 문제라고만 나오고, 코드 오류 케이스는 나오지 않았음 .. 그렇다고 버킷에 문제가 있다기엔 프로필이미지는 업로드가 잘됐음;;.. 해결 방법은 나도 모르겠고 집에 와서 한 .. 참 삽질-롤백 하다가 다현이 거 풀 받고 또 한...참 삽질-롤백하다가 롤백롤백 원래 코드로 했더니 됐음...... 내코드는 아무것도 바꾼것이 없는데...  너무슬펐다..

### 5. @RequestPart(value = "images", required = false)
본문이 텍스트로만 이루어진 기사의 경우엔 이미지 필드가 필요없으므로 required = false 처리를 해줘야 한다.

## 🔖 관련 이슈
### #43 [feat] 기사 API
