### PR TITLE
Refact Article 기사 API 재구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     //jackson 모듈 추가
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.17.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.jsoup:jsoup:1.15.4'  // 사용하려는 Jsoup 버전
 
 }
 

--- a/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
+++ b/src/main/java/com/example/onlinenews/article/api/ArticleAPI.java
@@ -54,6 +54,7 @@ public interface ArticleAPI {
 
     @PatchMapping("update/{id}")
     @Operation(summary = "기사 수정", description = "기사를 수정합니다.")
-    ResponseEntity<ArticleResponseDTO> updateArticle(@PathVariable Long id, @RequestBody ArticleUpdateRequestDTO updateRequest);
-
+    ResponseEntity<?> updateArticle(@PathVariable Long id,
+                                                     @RequestPart("requestDTO") ArticleUpdateRequestDTO updateRequest,
+                                                     @RequestPart(value = "images", required = false) List<MultipartFile> images);
 }

--- a/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
+++ b/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
@@ -77,7 +77,7 @@ public class ArticleController implements ArticleAPI {
 
     // 기사 수정
     @Override
-    public ResponseEntity<ArticleResponseDTO> updateArticle(@PathVariable Long id, @RequestBody ArticleUpdateRequestDTO updateRequest) {
-        return articleService.updateArticle(id, updateRequest);
+    public ResponseEntity<?> updateArticle(Long id, ArticleUpdateRequestDTO updateRequest, List<MultipartFile> images) {
+        return articleService.updateArticle(id, updateRequest, images);
     }
 }

--- a/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
@@ -1,17 +1,11 @@
 package com.example.onlinenews.article.dto;
 
 import com.example.onlinenews.article.entity.Category;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Data
 public class ArticleRequestDTO {
     private Category category;
     private String title;

--- a/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleRequestDTO.java
@@ -3,8 +3,6 @@ package com.example.onlinenews.article.dto;
 import com.example.onlinenews.article.entity.Category;
 import lombok.*;
 
-import java.util.List;
-
 @Data
 public class ArticleRequestDTO {
     private Category category;

--- a/src/main/java/com/example/onlinenews/article/dto/ArticleUpdateRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleUpdateRequestDTO.java
@@ -1,23 +1,13 @@
 package com.example.onlinenews.article.dto;
 
 import com.example.onlinenews.article.entity.Category;
-import com.example.onlinenews.article_img.entity.ArticleImg;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import java.util.List;
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Data
 public class ArticleUpdateRequestDTO {
     private String title;
     private String subtitle;
     private String content;
     private Category category;
-    private List<ArticleImg> images;
     private Boolean isPublic;
 }

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -29,9 +29,7 @@ import org.jsoup.nodes.Element;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -172,7 +170,7 @@ public class ArticleService {
 
     // 기사 수정
     @Transactional
-    public ResponseEntity<ArticleResponseDTO> updateArticle(Long id, ArticleUpdateRequestDTO updateRequest) {
+    public ResponseEntity<?> updateArticle(Long id, ArticleUpdateRequestDTO updateRequest, List<MultipartFile> images ) {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.ARTICLE_NOT_FOUND));
 
@@ -182,23 +180,43 @@ public class ArticleService {
         if (updateRequest.getSubtitle() != null) {
             article.setSubtitle(updateRequest.getSubtitle());
         }
-        if (updateRequest.getContent() != null) {
-            article.setContent(updateRequest.getContent());
-        }
         if (updateRequest.getCategory() != null) {
             article.setCategory(updateRequest.getCategory());
-        }
-        if (updateRequest.getImages() != null) {
-            article.setImages(updateRequest.getImages());
         }
         if (updateRequest.getIsPublic() != null) {
             article.setIsPublic(updateRequest.getIsPublic());
         }
 
-        article.setModifiedAt(LocalDateTime.now());
+        if (updateRequest.getContent() != null) {
 
-        Article updatedArticle = articleRepository.save(article); // 변경사항 저장
-        return ResponseEntity.ok(convertToResponseDTO(updatedArticle));
+            List<String> imageUrls = new ArrayList<>();
+            if (images != null && !images.isEmpty()) {
+                for (MultipartFile file : images) {
+                    if (file.isEmpty()) {
+                        throw new BusinessException(ExceptionCode.FILE_NOT_FOUND);
+                    }
+                    imageUrls.add(saveImg(file));
+
+                    List<ArticleImg> articleImgs = new ArrayList<>();
+                    for (String url : imageUrls) {
+                        ArticleImg articleImg = ArticleImg.builder()
+                                .article(article)
+                                .imgUrl(url)
+                                .build();
+                        articleImgs.add(articleImg);
+                        articleImgRepository.saveAll(articleImgs);
+                    }
+                }
+                article.setContent(replaceImgUrl(updateRequest.getContent(), imageUrls));
+
+            }
+            else article.setContent(updateRequest.getContent());
+        }
+
+        article.setModifiedAt(LocalDateTime.now());
+        articleRepository.save(article);
+
+        return ResponseEntity.ok("기사가 수정되었습니다. 편집장의 승인 후 게시됩니다.");
     }
 
     public void incrementViewCount(Long articleId) {

--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -6,10 +6,7 @@ import lombok.Getter;
 public enum ExceptionCode {
 
 
-    ARTICLE_NOT_FOUND(404, "ARTICLE_001", "해당되는 id 의 기사를 찾을 수 없습니다."),
     REPLY_NOT_FOUND(404, "REPLY_001", "해당되는 id의 댓글을 찾을 수 없습니다."),
-
-
 
     USER_NOT_FOUND(404, "USER_004", "해당 유저를 찾을 수 없습니다."),
     TOKEN_EXPIRED(401, "TOKEN_001", "토큰이 만료되었습니다. 다시 로그인 해주세요."),
@@ -42,8 +39,9 @@ public enum ExceptionCode {
     // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
     NOT_VALID_ERROR(404, "G011", "Validation Exception 발생"),
 
-    S3_UPLOAD_FAILED( 500, "Article_002", "이미지 업로드에 실패했습니다."),
-    FILE_NOT_FOUND(400, "Article_001", "존재하지 않는 파일입니다.");
+    ARTICLE_NOT_FOUND(404, "ARTICLE_001", "해당되는 id 의 기사를 찾을 수 없습니다."),
+    S3_UPLOAD_FAILED( 500, "ARTICLE_002", "이미지 업로드에 실패했습니다."),
+    FILE_NOT_FOUND(400, "ARTICLE_003", "존재하지 않는 파일입니다.");
 
 
 


### PR DESCRIPTION
## 🔗PR 타입
- [ ]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [x]  refact : 코드 리팩토링
- [x]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1. 이미지 저장 로직 변경
### 2. 기사 수정 API 이미지 변경할 수 있도록 재구성
### 3.   build.gradle 에 JSOUP 추가

## ✅ 테스트 결과
### 2. 수정 API 재구성 #47

## 💦 회고
### 1. HTML 속에 있는 이미지 src를 서버에 저장하는 방법
blob을 form-data로 변환하니까 이미지 url이 바뀌더라.....

그럼 img 태그에 있는 url이랑 클라우드/DB에 저장된 이미지 url이 다르겠지............ 그럼 나중에 기사 들고 올 때 이미지가 들고와지지않겠지......... 하하하;

두 가지 시도를 해 봤는데 첫 번째는 이미지 저장/삭제 API를 따로 만들어서 quill에서 이미지를 저장/삭제할 때 마다 이 API를 부르고, 서버 이미지로 교체한 후 백으로 보내는 거였다. 이렇게 하면 프론트를 싹 다 갈아엎어야 해서 너무너무 괴로워짐.... 나는 더이상 quill을 만지고 싶지 않았다. .. ... 더더욱 이미지 핸들러는 정말 고치고 싶지않았다... 좀만 건들면 이미지 리사이즈 뻑난다고요

그래서 백엔드에서 데이터를 정제하여 해결했다. Article 테이블에 데이터 넣기 전 이미지를 서버에 먼저 올리고, HTML의 이미지 태그를 JSOUP.parse로 가져온 후 src를 서버에 올라간 이미지로 변경하였다. 마지막으로 Article과 Article_img에 데이터를 넣었다...... 

이렇게 하고 수정메소드를 다시 손보는데, 이러면 이미지 삭제는 어떻게 하느냐에 대한 의문이 생겼다. 삭제는 화끈하게 하지 않으려 했는데, 그러면 리스트 형식으로 볼 때 썸네일은 어떻게 지정하는가~에 대한 생각도 들었다 ! 근데 이건 프론트 단에서 해결될 것 같기 때문에 무시할거임. find img 하면 첫번째 이미지 가져와지니까 ㅎㅎ;; 어케든 될것같아요! 

안 쓰는 이미지에 대한 생각은 좀 더 해 봐야 할 것 같다.. 일단 지금 생각으론? 수정 메소드 마지막에 content에 있는 img src랑 article_img를 비교해서 content에 없는 이미지를 삭제하면 될 것 같긴 한데, .. 일단 오늘은 그만할거임

## 🔖 관련 이슈
### #43 [feat] 기사 API