### PR TITLE
feat: 비공개, 공개 , 현재 공개 상태 확인 기능 구현

### DIFF
--- a/src/main/java/com/example/onlinenews/article/entity/Article.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Article.java
@@ -70,4 +70,7 @@ public class Article {
     public void updateStatue(RequestStatus newRequestStatus) {
         this.state= newRequestStatus;
     }
+    public void updateIsPublic(Boolean newIsPublic){
+        this.isPublic = newIsPublic;
+    }
 }

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -234,11 +234,6 @@ public class ArticleService {
         articleRepository.save(article); // 변경사항 저장
     }
 
-    //편집장 요청 처리 시 수정됨
-    public void statusUpdate(Long articleId, RequestStatus newRequestStatus){
-        Article article = articleRepository.findById(articleId).orElseThrow(() -> new BusinessException(ExceptionCode.ARTICLE_NOT_FOUND));
-        article.updateStatue(newRequestStatus);
-    }
 
 
     private ArticleResponseDTO convertToResponseDTO(Article article) {

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -222,6 +222,11 @@ public class ArticleService {
         article.setModifiedAt(LocalDateTime.now());
         articleRepository.save(article);
 
+        //승인요청
+        if(article.getUser().getGrade().getValue() < UserGrade.REPORTER.getValue()){
+            requestService.create(article.getUser(), article);
+        }
+
         return ResponseEntity.ok("기사가 수정되었습니다. 편집장의 승인 후 게시됩니다.");
     }
 

--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -27,6 +27,8 @@ public enum ExceptionCode {
     ALREADY_APPROVED(400, "REQUEST_002", "이미 '승인' 한 상태입니다."),
     ALREADY_HOLDING(400, "REQUEST_003", "이미 '보류' 한 상태입니다."),
     ALREADY_REJECTED(400, "REQUEST_004", "이미 '거절' 한 상태입니다."),
+    ALREADY_PUBLIC(400, "REQUEST_005", "이미 공개상태입니다."),
+    ALREADY_PRIVATE(400, "REQUEST_006", "이미 비공개 상태입니다."),
 
     NOTIFICATION_NOT_FOUND(404, "NOTIFICATION_001", "해당되는 id 의 알림을 찾을 수 없습니다."),
     ARTICLE_LIKE_NOT_FOUND(404,"ARTICLE_LIKE_001", "해당되는 id의 좋아요를 찾을 수 없습니다."),

--- a/src/main/java/com/example/onlinenews/request/api/RequestApi.java
+++ b/src/main/java/com/example/onlinenews/request/api/RequestApi.java
@@ -41,8 +41,20 @@ public interface RequestApi {
     ResponseEntity<?> requestHold(HttpServletRequest request, @PathVariable Long reqId, @RequestBody RequestCommentDto requestCommentDto);
 
     @PutMapping("/{reqId}/reject")
-    @Operation(summary = "요청 id로 요청 조회", description = "편집장이 id에 해당하는 요청을 거절하고 커멘트를 남깁니다.")
+    @Operation(summary = "요청 거절", description = "편집장이 id에 해당하는 요청을 거절하고 커멘트를 남깁니다.")
     ResponseEntity<?> requestReject(HttpServletRequest request, @PathVariable Long reqId, @RequestBody RequestCommentDto requestCommentDto);
+
+    @PatchMapping("/{reqId}/private")
+    @Operation(summary = "기사 비공개 ", description = "편집장이 기사를 비공개합니다.")
+    boolean convertToPrivate(HttpServletRequest request, @PathVariable Long reqId);
+
+    @PatchMapping("/{reqId}/public")
+    @Operation(summary = "기사 공개 ", description = "편집장이 기사를 공개합니다.")
+    boolean convertToPublic(HttpServletRequest request, @PathVariable Long reqId);
+
+    @GetMapping("/{reqId}/public-status")
+    @Operation(summary = "요청 id로 요청 조회", description = "요청아이디(path)로 해당 요청을 조회합니다.")
+    boolean getPublicStatus(@PathVariable Long reqId);
 
     @GetMapping("/status")
     @Operation(summary = "상태별로 요청 조회", description = "상태를 입력(param)하여 해당 상태의 요청들을 조회합니다.")

--- a/src/main/java/com/example/onlinenews/request/controller/RequestController.java
+++ b/src/main/java/com/example/onlinenews/request/controller/RequestController.java
@@ -64,6 +64,23 @@ public class RequestController implements RequestApi {
     }
 
     @Override
+    public boolean convertToPrivate(HttpServletRequest request, Long reqId) {
+        String email = authService.getEmailFromToken(request);
+        return requestService.convertToPrivate(email,reqId);
+    }
+
+    @Override
+    public boolean convertToPublic(HttpServletRequest request, Long reqId) {
+        String email = authService.getEmailFromToken(request);
+        return  requestService.convertToPublic(email,reqId);
+    }
+
+    @Override
+    public boolean getPublicStatus(Long reqId) {
+        return  requestService.getPublicStatus(reqId);
+    }
+
+    @Override
     public List<RequestDto> getByStatus(HttpServletRequest request, String keyword) {
         String email = authService.getEmailFromToken(request);
         return requestService.getByStatus(email, keyword);

--- a/src/main/java/com/example/onlinenews/request/service/RequestService.java
+++ b/src/main/java/com/example/onlinenews/request/service/RequestService.java
@@ -104,6 +104,7 @@ public class RequestService {
 
         //기사 상태 업데이트
         request.getArticle().updateStatue(request.getStatus());
+        request.getArticle().updateIsPublic(true);
 
         //승인 알림
         notificationService.createApprovedNoti(request);
@@ -145,6 +146,35 @@ public class RequestService {
         //거절 알림
         notificationService.createRejectedNoti(request);
         return request.getStatus();
+    }
+
+    //승인된 요청은 공개 비공개 설정가능
+    @Transactional
+    public boolean convertToPrivate(String email, Long reqId){
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+        checkEditorPermission(user);
+        Request request = requestRepository.findById(reqId).orElseThrow(() -> new BusinessException(ExceptionCode.REQUEST_NOT_FOUND));
+        if(!request.getArticle().getIsPublic()){
+            throw new BusinessException(ExceptionCode.ALREADY_PRIVATE);
+        }
+        request.getArticle().updateIsPublic(false);
+        return request.getArticle().getIsPublic();
+    }
+    @Transactional
+    public boolean convertToPublic(String email, Long reqId){
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+        checkEditorPermission(user);
+        Request request = requestRepository.findById(reqId).orElseThrow(() -> new BusinessException(ExceptionCode.REQUEST_NOT_FOUND));
+        if(request.getArticle().getIsPublic()){
+            throw new BusinessException(ExceptionCode.ALREADY_PUBLIC);
+        }
+        request.getArticle().updateIsPublic(true);
+        return request.getArticle().getIsPublic();
+    }
+
+    public boolean getPublicStatus(Long reqId){
+        Request request = requestRepository.findById(reqId).orElseThrow(() -> new BusinessException(ExceptionCode.REQUEST_NOT_FOUND));
+        return request.getArticle().getIsPublic();
     }
 
     //상태로 요청조회


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [x]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
1. 승인 된 기사를 공개, 비공개 처리하는 기능
2. 현재 기사가 공개인지 비공개인지 확인하는 기능
3. 기사 수정 시 요청 다시 전송
4. 승인 완료 되기 전에는 isPublic 이 false 이고, 승인되면 true가 됩니다.   

## ✅ 테스트 결과

1. 기사 공개 상태 확인
![스크린샷 2024-11-11 173841](https://github.com/user-attachments/assets/30410701-dddb-4dc4-bbe2-50d0007d1a87)
2. 기사 공개, 비공개
![스크린샷 2024-11-11 223556](https://github.com/user-attachments/assets/b8da7d47-e137-4a36-a140-167f45fcea91)
3. 기사 공개, 비공개 했는데 또누름
![스크린샷 2024-11-11 223909](https://github.com/user-attachments/assets/297feee8-0f6b-4f89-bcac-f931fdfac225)
