### PR TITLE
refact: 기사 수정 이미지 삭제 구현중

### DIFF
--- a/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
+++ b/src/main/java/com/example/onlinenews/article/controller/ArticleController.java
@@ -30,6 +30,7 @@ public class ArticleController implements ArticleAPI {
         return articleService.createArticle(requestDTO, email, images);
     }
 
+    // 기사 조회
     @Override
     public ResponseEntity<?> getArticles(Long id, Category category, String title, String content, Long userId, RequestStatus state, Boolean isPublic, String sortBy, String sortDirection) {
         return articleService.getArticles(id, category, title, content, userId, state, isPublic, sortBy, sortDirection);

--- a/src/main/java/com/example/onlinenews/article/dto/ArticleUpdateRequestDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleUpdateRequestDTO.java
@@ -3,6 +3,8 @@ package com.example.onlinenews.article.dto;
 import com.example.onlinenews.article.entity.Category;
 import lombok.*;
 
+import java.util.List;
+
 @Data
 public class ArticleUpdateRequestDTO {
     private String title;
@@ -10,4 +12,5 @@ public class ArticleUpdateRequestDTO {
     private String content;
     private Category category;
     private Boolean isPublic;
+    private List<String> deleteImages;
 }

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -275,6 +275,7 @@ public class ArticleService {
     }
 
 
+    // 서버에 이미지 저장
     public String saveImg(MultipartFile file){
         String originalFilename = file.getOriginalFilename();
         String fileExtension = "";
@@ -294,6 +295,7 @@ public class ArticleService {
         return fileUrl;
     }
 
+    // 서버에서 이미지 삭제
     public void deleteImg(String imgUrl) {
         try {
             String fileName = extractFileNameFromUrl(imgUrl);
@@ -301,20 +303,17 @@ public class ArticleService {
                     bucketName,
                     "articleImg/" + fileName
             );
-
-            // S3에서 이미지 삭제
             amazonS3.deleteObject(deleteObjectRequest);
         } catch (Exception e) {
-            System.out.println("Error during delete operation: " + e.getMessage());
             throw new BusinessException(ExceptionCode.FILE_DELETE_FAILED);
         }
     }
-
     public String extractFileNameFromUrl(String url) {
         String[] urlParts = url.split("/");
         return urlParts[urlParts.length - 1];
     }
 
+    // 서버에 올라간 url으로 변경
     public String replaceImgUrl(String content, List<String> imgUrls) {
         Document document = Jsoup.parse(content);
         List<Element> images = document.select("img");

--- a/src/main/java/com/example/onlinenews/article_img/repository/ArticleImgRepository.java
+++ b/src/main/java/com/example/onlinenews/article_img/repository/ArticleImgRepository.java
@@ -4,4 +4,5 @@ import com.example.onlinenews.article_img.entity.ArticleImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleImgRepository extends JpaRepository<ArticleImg, Long> {
+    void deleteByImgUrl(String imgUrl);
 }

--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -44,7 +44,8 @@ public enum ExceptionCode {
 
     ARTICLE_NOT_FOUND(404, "ARTICLE_001", "해당되는 id 의 기사를 찾을 수 없습니다."),
     S3_UPLOAD_FAILED( 500, "ARTICLE_002", "이미지 업로드에 실패했습니다."),
-    FILE_NOT_FOUND(400, "ARTICLE_003", "존재하지 않는 파일입니다.");
+    FILE_NOT_FOUND(400, "ARTICLE_003", "존재하지 않는 파일입니다."),
+    FILE_DELETE_FAILED(400, "ARTICLE_004", "이미지 삭제에 실패했습니다.");
 
 
 


### PR DESCRIPTION
## 🔗PR 타입
- [ ]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [x]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [x]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1. 기사 본문 수정할 때 삭제된 이미지 처리

## ✅ 테스트 결과
### 1. requestDTO의 deleteImages에 삭제할 이미지 url 넣으면 서버와 article_img 테이블에서 삭제됨
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/12764d82-b98a-46c1-bd0f-959fa87a0915">

## 🔖 관련 이슈
### #43 [feat] 기사 API