### PR TITLE
Fix/#85 기사 본문 조회, 좋아요,  카테고리 수정

### DIFF
--- a/src/main/java/com/example/onlinenews/article/dto/ArticleResponseDTO.java
+++ b/src/main/java/com/example/onlinenews/article/dto/ArticleResponseDTO.java
@@ -1,7 +1,9 @@
 package com.example.onlinenews.article.dto;
 
 import com.example.onlinenews.article.entity.Category;
+import com.example.onlinenews.publisher.entity.Publisher;
 import com.example.onlinenews.request.entity.RequestStatus;
+import com.example.onlinenews.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,6 +26,15 @@ public class ArticleResponseDTO {
     private LocalDateTime approvedAt;
     private RequestStatus state;
     private Boolean isPublic;
+    private long userId;
+    private String userEmail;
+    private String userName;
+    private String userBio;
+    private String userImg;
+    private long publisherId;
+    private String publisherName;
+    private String publisherUrl;
+    private String publisherImage;
     private int views;
     private int likes;
     private List<String> images;

--- a/src/main/java/com/example/onlinenews/article/entity/Category.java
+++ b/src/main/java/com/example/onlinenews/article/entity/Category.java
@@ -8,7 +8,9 @@ public enum Category {
     ECONOMY("경제"),
     LIFE_CULTURE("생활/문화"),
     ENTERTAINMENT("연예"),
-    SCIENCE_TECH("과학/기술");
+    SCIENCE_TECH("기계/IT"),
+    POLITICS("정치"),
+    OPINION("오피니언");
 
     private final String description;
 

--- a/src/main/java/com/example/onlinenews/article/service/ArticleService.java
+++ b/src/main/java/com/example/onlinenews/article/service/ArticleService.java
@@ -270,6 +270,15 @@ public class ArticleService {
                 .state(article.getState())
                 .isPublic(article.getIsPublic())
                 .views(article.getViews())
+                .userId(article.getUser().getId())
+                .userEmail(article.getUser().getEmail())
+                .userName(article.getUser().getName())
+                .userBio(article.getUser().getBio())
+                .userImg(article.getUser().getImg())
+                .publisherId(article.getUser().getPublisher().getId())
+                .publisherName(article.getUser().getPublisher().getName())
+                .publisherUrl(article.getUser().getPublisher().getUrl())
+                .publisherImage(article.getUser().getPublisher().getImg())
                 .images(images.stream().map(img -> img.getImgUrl()).collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/com/example/onlinenews/like/api/ArticleLikeApi.java
+++ b/src/main/java/com/example/onlinenews/like/api/ArticleLikeApi.java
@@ -31,6 +31,6 @@ public interface ArticleLikeApi {
 
     @GetMapping("/{articleId}/like/check")
     @Operation(summary = "좋아요 여부 체크", description = "좋아요 눌렀는 지 확인합니다")
-    boolean checkLike(HttpServletRequest request,  @PathVariable Long articleId);
+    Long checkLike(HttpServletRequest request,  @PathVariable Long articleId);
 
 }

--- a/src/main/java/com/example/onlinenews/like/controller/ArticleLikeController.java
+++ b/src/main/java/com/example/onlinenews/like/controller/ArticleLikeController.java
@@ -43,7 +43,7 @@ public class ArticleLikeController implements ArticleLikeApi {
     }
 
     @Override
-    public boolean checkLike(HttpServletRequest request, Long articleId) {
+    public Long checkLike(HttpServletRequest request, Long articleId) {
         String email = authService.getEmailFromToken(request);
         return articleLikeService.checkLike(email, articleId);
     }

--- a/src/main/java/com/example/onlinenews/notification/repository/JournalistNotificationRepository.java
+++ b/src/main/java/com/example/onlinenews/notification/repository/JournalistNotificationRepository.java
@@ -1,0 +1,15 @@
+package com.example.onlinenews.notification.repository;
+
+import com.example.onlinenews.notification.entity.JournalistNotification;
+import com.example.onlinenews.like.entity.ArticleLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface JournalistNotificationRepository extends JpaRepository<JournalistNotification, Long> {
+
+    @Query("SELECT jn FROM JournalistNotification jn WHERE jn.articleLike = :articleLike")
+    List<JournalistNotification> findByArticleLike(@Param("articleLike") ArticleLike articleLike);
+}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1. 기사 조회 시 기자 정보(이름, 이메일, 프로필이미지, 바이오), 신문사 정보(이름, 링크, 로고이미지) 추가
### 2. 기사 본문 좋아요 시 response: 성공메시지에서 ArticlelikeID로 변경(그래야좋아요취소를할수있기때문)
### 3. 기사 본문 좋아요 취소 시 생기는 버그 고침
> 좋아요 삭제하려면 notifications까지 삭제해야 했는데, 알림 레포지토리에 findbyArticleLike 생성했더니 ArticleLike가 아니라 Article을 찾아서 계속 오류남;; 그래서 그냥 쿼리 박아넣었다... 난모르겟다너무힘들다........진짜로...할게너무많다....
### 4. article entity 카테고리 enum 수정
자동 반영 안 돼서 디비 직접 수정했음
`ALTER TABLE article MODIFY COLUMN category ENUM('SOCIAL', 'ECONOMY', 'LIFE_CULTURE', 'ENTERTAINMENT', 'SCIENCE_TECH', 'POLITICS', 'OPINION');
`

## ✅ 테스트 결과
프론트에 적겠습니다...

## 🥹 회고
<img width="430" alt="image" src="https://github.com/user-attachments/assets/239e2082-d35d-497b-830a-9f7a393e5ecd">

<img width="571" alt="image" src="https://github.com/user-attachments/assets/37e09234-ed40-4dfe-98f0-05950459de2a">

기사 작성할 때 작성 성공한 후 user_004 오류나는 이유 찾은것같은데, 내가 짠 부분이 아니라서 이해가 잘 안 됨
실제로 알림 DB에 안 들어가 있다 .. !!!!!!!! 이유가 뭔지는 @jjjjjinseo 에게 물어봐야함

## 🔖 관련 이슈
### #85 [fix] Article API