### PR TITLE
Feat/#46 mailing add : 메일링 서비스 스케줄링 구현 

### DIFF
--- a/src/main/java/com/example/onlinenews/OnlineNewsApplication.java
+++ b/src/main/java/com/example/onlinenews/OnlineNewsApplication.java
@@ -3,9 +3,11 @@ package com.example.onlinenews;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class OnlineNewsApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/onlinenews/mailing/service/MailingBackgroundService.java
+++ b/src/main/java/com/example/onlinenews/mailing/service/MailingBackgroundService.java
@@ -23,7 +23,7 @@ public class MailingBackgroundService {
     private MailingRepository mailingRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0 22 * * * ?")
+    @Scheduled(cron = "0 0 22 * * ?")
     public void sendDailyEmails() {
         // 메일링 구독자를 가져옵니다.
         List<Mailing> mailingList = mailingRepository.findAll();

--- a/src/main/java/com/example/onlinenews/mailing/service/MailingBackgroundService.java
+++ b/src/main/java/com/example/onlinenews/mailing/service/MailingBackgroundService.java
@@ -1,0 +1,58 @@
+package com.example.onlinenews.mailing.service;
+
+
+import com.example.onlinenews.mailing.dto.MailArticleDto;
+import com.example.onlinenews.mailing.entity.Mailing;
+import com.example.onlinenews.mailing.repository.MailingRepository;
+import jakarta.mail.MessagingException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MailingBackgroundService {
+
+    @Autowired
+    private MailingService mailingService;
+
+    @Autowired
+    private MailingRepository mailingRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 22 * * * ?")
+    public void sendDailyEmails() {
+        // 메일링 구독자를 가져옵니다.
+        List<Mailing> mailingList = mailingRepository.findAll();
+
+        List<MailArticleDto> headArticles = mailingService.getHeadArticlesByCategory();
+        if (!headArticles.isEmpty() && !mailingList.isEmpty()) {
+            String emailContent = mailingService.generateEmailTemplate(headArticles);
+
+            // 오늘의 날짜 생성
+            LocalDate today = LocalDate.now();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            String formattedDate = today.format(formatter);
+
+            for (Mailing mailing : mailingList) {
+                String recipientEmail = mailing.getUser().getEmail();
+
+                try {
+                    // HTML 이메일 발송
+                    mailingService.sendHtmlMail(recipientEmail, "오늘의 뉴스 다이제스트 - " + formattedDate, emailContent);
+                    System.out.println("메일 발송 완료: " + recipientEmail);
+                } catch (MessagingException e) {
+                    System.err.println("메일 발송 실패: " + recipientEmail);
+                    e.printStackTrace();
+                }
+            }
+        } else {
+            System.out.println("오늘은 보낼 메일이 없네요");
+        }
+
+
+    }
+}

--- a/src/main/java/com/example/onlinenews/mailing/service/MailingService.java
+++ b/src/main/java/com/example/onlinenews/mailing/service/MailingService.java
@@ -23,6 +23,7 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
@@ -59,7 +60,7 @@ public class MailingService {
         sendHtmlMail(to, "Today's Headlines", emailContent);
     }
 
-    private void sendHtmlMail(String to, String subject, String content) throws MessagingException {
+    void sendHtmlMail(String to, String subject, String content) throws MessagingException {
         MimeMessage message = javaMailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
@@ -74,7 +75,8 @@ public class MailingService {
         }
     }
 
-    private List<MailArticleDto> getHeadArticlesByCategory() {
+    @Transactional
+    List<MailArticleDto> getHeadArticlesByCategory() {
         List<MainArticle> articles = mainArticleService.getHeadArticlesForToday();
 
         List<MailArticleDto> mailArticles = new ArrayList<>();
@@ -95,7 +97,7 @@ public class MailingService {
         return mailArticles;
     }
 
-    private String generateEmailTemplate(List<MailArticleDto> articles) {
+    public String generateEmailTemplate(List<MailArticleDto> articles) {
         Context context = new Context();
         context.setVariable("articles", articles);  // articles 변수로 템플릿에 전달
 


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 머지는 최종 개발 완료 후에 해봅시다요 DB에 테스트로 넣어둔 이메일 중에 혹시 제3자에게  이메일 갈 수도 있으니... 

### 1.   메일링 서비스 구현 
> 매일 특정 시간에, 메일링 구독자들에게 오늘의 카테고리별 헤드기사를 발송하는 메일링 서비스 구현
이때 메일링 구독자가 한명도 없거나 오늘의 헤드기사가 선정된게 없으면 발송하지 않음
백그라운드로 실행되는 것이기 때문에 따로 API를 호출해야한다던가 하지 않습니답 

## ✅ 테스트 결과
### 1.   스케줄링을 2분마다로 설정했을때 발송 결과 화면 
|데스크탑|모바일앱(지메일)|
|-|-|
|![image](https://github.com/user-attachments/assets/4d1b3d4e-900f-406f-9095-c18e4c68279a)|![image](https://github.com/user-attachments/assets/5a08b380-97f6-475b-ac43-6f878f6c13cc)|

### 2. 스케줄링을 특정 시간(밤 10시)으로 했을때도 잘 동작합니다
<img width="461" alt="image" src="https://github.com/user-attachments/assets/0a689af8-eb9c-42ec-b119-8154b8b0f779">


## 🔖 관련 이슈
### #46
