### PR TITLE
Feat/#137 token add : 토큰 재발급 API 생성 및 토큰 검증 에러 처리 수정 

### DIFF
--- a/src/main/java/com/example/onlinenews/error/ExceptionCode.java
+++ b/src/main/java/com/example/onlinenews/error/ExceptionCode.java
@@ -9,19 +9,20 @@ public enum ExceptionCode {
     REPLY_NOT_FOUND(404, "REPLY_001", "해당되는 id의 댓글을 찾을 수 없습니다."),
 
     USER_NOT_FOUND(404, "USER_004", "해당 유저를 찾을 수 없습니다."),
-    TOKEN_EXPIRED(401, "TOKEN_001", "토큰이 만료되었습니다. 다시 로그인 해주세요."),
+    TOKEN_EXPIRED(401, "TOKEN_001", "토큰이 만료되었습니다. 토큰을 재발급하거나 다시 로그인하세요."),
     TOKEN_NOT_VALID(401, "TOKEN_002", "유효하지 않는 토큰입니다."),
+    REFRESH_TOKEN_EXPIRED(401, "TOKEN_003", "리프래쉬 토큰이 만료되었습니다. 다시 로그인해주세요"),
     USER_CAN_NOT_BE_NULL(400, "USER_005", "사용자는 null이 될 수 없습니다."),
     USER_ID_NOT_FOUND(404, "USER_006", "해당되는 id의 사용자를 찾을 수 없습니다."),
     USER_NOT_ALLOWED(404, "USER_007", "편집장 이상만 가능한 작업입니다."),
-    USER_PASSWORD_INCORRECT(401, "USER_008", "비밀번호가 틀렸습니다."),
+    USER_PASSWORD_INCORRECT(400, "USER_008", "비밀번호가 틀렸습니다."),
     INVITE_CODE_MISMATCH(400, "KEY_001", "올바르지 않는 초대코드 입니다."),
     PUBLISHER_NOT_FOUND(404, "PUB_001", "해당 이름의 신문사를 찾을 수 없습니다."),
     SUB_NOT_FOUND(404, "SUB_001", "구독 정보를 찾을 수 없습니다."),
 
     EMAIL_CONFLICT(409, "EMAIL_009", "이미 존재하는 email입니다. "),
 
-    HISTORY_NOT_FOUND(400,"HIS_001","존재하지 않는 검색 기록입니다."),
+    HISTORY_NOT_FOUND(400, "HIS_001", "존재하지 않는 검색 기록입니다."),
 
     REQUEST_NOT_FOUND(404, "REQUEST_001", "해당되는 id 의 요청을 찾을 수 없습니다."),
     ALREADY_APPROVED(400, "REQUEST_002", "이미 '승인' 한 상태입니다."),
@@ -31,8 +32,8 @@ public enum ExceptionCode {
     ALREADY_PRIVATE(400, "REQUEST_006", "이미 비공개 상태입니다."),
 
     NOTIFICATION_NOT_FOUND(404, "NOTIFICATION_001", "해당되는 id 의 알림을 찾을 수 없습니다."),
-    ARTICLE_LIKE_NOT_FOUND(404,"ARTICLE_LIKE_001", "해당되는 id의 좋아요를 찾을 수 없습니다."),
-    USER_MISMATCH(400,"USER_010", "본인에게 속하지 않은 항목에 대한 작업은 허용되지 않습니다."),
+    ARTICLE_LIKE_NOT_FOUND(404, "ARTICLE_LIKE_001", "해당되는 id의 좋아요를 찾을 수 없습니다."),
+    USER_MISMATCH(400, "USER_010", "본인에게 속하지 않은 항목에 대한 작업은 허용되지 않습니다."),
     ALREADY_LIKED(400, "LIKE_001", "이미 '좋아요'를 누른 상태입니다."),
 
     NULL_POINT_ERROR(404, "G010", "NullPointerException 발생"),
@@ -45,15 +46,11 @@ public enum ExceptionCode {
     NOT_VALID_ERROR(404, "G011", "Validation Exception 발생"),
 
     ARTICLE_NOT_FOUND(404, "ARTICLE_001", "해당되는 기사를 찾을 수 없습니다."),
-    S3_UPLOAD_FAILED( 500, "ARTICLE_002", "이미지 업로드에 실패했습니다."),
+    S3_UPLOAD_FAILED(500, "ARTICLE_002", "이미지 업로드에 실패했습니다."),
     FILE_NOT_FOUND(400, "ARTICLE_003", "존재하지 않는 파일입니다."),
     FILE_DELETE_FAILED(400, "ARTICLE_004", "이미지 삭제에 실패했습니다."),
 
     COMMENT_NOT_FOUND(404, "COMMENT_001", "해당되는 댓글을 찾을 수 없습니다.");
-
-
-
-
 
     // 1. status = 날려줄 상태코드
     // 2. code = 해당 오류가 어느부분과 관련있는지 카테고리화 해주는 코드. 예외 원인 식별하기 편하기에 추가

--- a/src/main/java/com/example/onlinenews/jwt/api/JwtApi.java
+++ b/src/main/java/com/example/onlinenews/jwt/api/JwtApi.java
@@ -1,0 +1,17 @@
+package com.example.onlinenews.jwt.api;
+
+import com.example.onlinenews.jwt.dto.JwtToken;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/token")
+@Tag(name = "token", description = "토큰 관련 API")
+public interface JwtApi {
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 갱신", description = "refresh token으로 토큰을 재발급합니다.")
+    ResponseEntity<JwtToken> reissue(@RequestBody String refreshToken);
+}

--- a/src/main/java/com/example/onlinenews/jwt/controller/JwtController.java
+++ b/src/main/java/com/example/onlinenews/jwt/controller/JwtController.java
@@ -1,0 +1,22 @@
+package com.example.onlinenews.jwt.controller;
+
+import com.example.onlinenews.jwt.api.JwtApi;
+import com.example.onlinenews.jwt.dto.JwtToken;
+import com.example.onlinenews.jwt.provider.JwtTokenProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class JwtController implements JwtApi {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtController(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public ResponseEntity<JwtToken> reissue(String refreshToken) {
+        return new ResponseEntity<>(jwtTokenProvider.reissueToken(refreshToken), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/onlinenews/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/onlinenews/jwt/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.example.onlinenews.jwt.filter;
 
 import com.example.onlinenews.error.BusinessException;
-import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.jwt.provider.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -26,27 +25,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+            throws ServletException, IOException, BusinessException {
         String token = jwtProvider.resolveToken(request);
         System.out.println("Resolved Token: " + token);  // 토큰이 올바르게 파싱되는지 확인
 
-        if (token != null) {
-            try {
+        try {
+            if (token != null) {
                 if (jwtProvider.validateToken(token)) {
                     Authentication auth = jwtProvider.getAuthentication(token);
                     SecurityContextHolder.getContext().setAuthentication(auth);
                 }
-            } catch (BusinessException e) {
-                // 예외 종류에 따라 다른 상태 코드 처리
-                if (e.getExceptionCode() == ExceptionCode.TOKEN_EXPIRED) {
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 만료된 토큰에 대해서 401 처리
-                    response.getWriter().write("Token expired. Please refresh your token.");
-                } else if (e.getExceptionCode() == ExceptionCode.TOKEN_NOT_VALID) {
-                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);  // 토큰이 유효하지 않은 경우 403 처리
-                    response.getWriter().write("Invalid token.");
-                }
-                return; // 인증 실패 시 필터 체인을 더 진행하지 않음
             }
+        } catch (BusinessException e) {
+            response.sendError(e.getExceptionCode().getStatus(), e.getExceptionCode().getMessage());
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import com.example.onlinenews.error.ExceptionCode;
 import com.example.onlinenews.jwt.dto.JwtToken;
 import com.example.onlinenews.jwt.service.JpaUserDetailService;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -142,6 +143,9 @@ public class JwtTokenProvider {
 
             return !claims.getBody().getExpiration().before(new Date());
 
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", token, e);
+            throw new BusinessException(ExceptionCode.TOKEN_EXPIRED);
         } catch (Exception e) {
             log.error("Invalid JWT token: {}", token, e);
             throw new BusinessException(ExceptionCode.TOKEN_NOT_VALID);

--- a/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/example/onlinenews/jwt/provider/JwtTokenProvider.java
@@ -177,7 +177,12 @@ public class JwtTokenProvider {
      * @return
      */
     public JwtToken reissueToken(String refreshToken) {
-        String email = getAccount(refreshToken);
+        String email;
+        try {
+            email = getAccount(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ExceptionCode.REFRESH_TOKEN_EXPIRED);
+        }
 
         JwtToken jwtDto = JwtToken.builder()
                 .accessToken(generateAccessToken(email))


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1.  토큰 재발급 API 개발 : /api/token/reissue 생성 
### 2. 비밀번호 오류 코드 401 -> 400으로 수정  
> 토큰 만료 및 사용자 권한 관련 오류에만 401 코드 사용
### 3. 토큰 유효성 검증 로직 수정 

## ✅ 테스트 결과
### 1.   토큰 재발급 API 테스트 

|accessToken 재발급|refreshToken도 만료되었을때|
|-|-|
|![image](https://github.com/user-attachments/assets/3cc7a26d-de9e-43be-a605-299c7673c0ad)|![image](https://github.com/user-attachments/assets/d230e034-ada0-4e1a-8197-341be8ec5ccf)|

## 🔖 관련 이슈
### #137
